### PR TITLE
feat(#120, #121, #122): 정치유형 검사 기능 구현

### DIFF
--- a/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeAnimalAdminController.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeAnimalAdminController.java
@@ -12,7 +12,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,7 +20,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/admin/political-type/animals")
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Admin-PoliticalType-Animal", description = "정치 유형 동물유형 콘텐츠 관리 API")
 public class PoliticalTypeAnimalAdminController {
 

--- a/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeAnimalAdminController.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeAnimalAdminController.java
@@ -1,0 +1,86 @@
+package com.graydang.app.domain.politicaltype.controller;
+
+import com.graydang.app.domain.politicaltype.dto.request.AnimalCreateRequest;
+import com.graydang.app.domain.politicaltype.dto.request.AnimalUpdateRequest;
+import com.graydang.app.domain.politicaltype.dto.response.AnimalAdminResponse;
+import com.graydang.app.domain.politicaltype.service.PoliticalTypeAnimalAdminService;
+import com.graydang.app.global.common.model.dto.BaseResponse;
+import com.graydang.app.global.common.model.enums.BaseResponseStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/political-type/animals")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Admin-PoliticalType-Animal", description = "정치 유형 동물유형 콘텐츠 관리 API")
+public class PoliticalTypeAnimalAdminController {
+
+    private final PoliticalTypeAnimalAdminService animalAdminService;
+
+    /** 동물유형 등록 (이미지 포함 Multipart). */
+    @Operation(summary = "동물유형 등록")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse<AnimalAdminResponse>> createAnimal(
+            @RequestPart("request") @Valid AnimalCreateRequest request,
+            @RequestPart(value = "image", required = false) MultipartFile image) {
+
+        AnimalAdminResponse response = animalAdminService.createAnimal(request, image);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 동물유형 전체 조회. */
+    @Operation(summary = "동물유형 전체 조회")
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<AnimalAdminResponse>>> getAllAnimals() {
+        List<AnimalAdminResponse> response = animalAdminService.getAllAnimals();
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 동물유형 단건 조회. */
+    @Operation(summary = "동물유형 단건 조회")
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<AnimalAdminResponse>> getAnimal(@PathVariable Long id) {
+        AnimalAdminResponse response = animalAdminService.getAnimal(id);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 동물유형 콘텐츠 수정 (이미지 제외). */
+    @Operation(summary = "동물유형 수정 (이미지 제외)")
+    @PutMapping("/{id}")
+    public ResponseEntity<BaseResponse<AnimalAdminResponse>> updateAnimal(
+            @PathVariable Long id,
+            @Valid @RequestBody AnimalUpdateRequest request) {
+
+        AnimalAdminResponse response = animalAdminService.updateAnimal(id, request);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 동물유형 이미지 교체. 기존 이미지 삭제 후 새 이미지 업로드. */
+    @Operation(summary = "동물유형 이미지 수정")
+    @PutMapping(value = "/{id}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse<AnimalAdminResponse>> updateAnimalImage(
+            @PathVariable Long id,
+            @RequestPart("image") MultipartFile image) {
+
+        AnimalAdminResponse response = animalAdminService.updateAnimalImage(id, image);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 동물유형 삭제. S3 이미지도 함께 삭제. */
+    @Operation(summary = "동물유형 삭제")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse<Void>> deleteAnimal(@PathVariable Long id) {
+        animalAdminService.deleteAnimal(id);
+        return ResponseEntity.ok(BaseResponse.success(BaseResponseStatus.SUCCESS));
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeController.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeController.java
@@ -1,0 +1,88 @@
+package com.graydang.app.domain.politicaltype.controller;
+
+import com.graydang.app.domain.auth.oauth2.CustomUserDetails;
+import com.graydang.app.domain.politicaltype.dto.request.TestSubmitRequest;
+import com.graydang.app.domain.politicaltype.dto.response.*;
+import com.graydang.app.domain.politicaltype.service.PoliticalTypeService;
+import com.graydang.app.global.common.model.dto.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/** 정치유형 검사 사용자 API. */
+@RestController
+@RequestMapping("/api/political-type")
+@RequiredArgsConstructor
+@Tag(name = "PoliticalType", description = "정치유형 검사 사용자 API")
+public class PoliticalTypeController {
+
+    private final PoliticalTypeService politicalTypeService;
+
+    @Operation(summary = "검사 문항 조회")
+    @GetMapping("/questions")
+    public ResponseEntity<BaseResponse<List<QuestionResponse>>> getQuestions() {
+        List<QuestionResponse> response = politicalTypeService.getQuestions();
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 비회원도 제출 가능. 인증 토큰이 있으면 자동 저장. */
+    @Operation(summary = "검사 답변 제출")
+    @PostMapping("/submit")
+    public ResponseEntity<BaseResponse<TestResultResponse>> submitTest(
+            @Valid @RequestBody TestSubmitRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        var user = userDetails != null ? userDetails.getUser() : null;
+        TestResultResponse response = politicalTypeService.submitTest(request, user);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "비회원 결과 저장 (로그인 후)")
+    @PostMapping("/save")
+    public ResponseEntity<BaseResponse<TestResultResponse>> saveResult(
+            @Valid @RequestBody TestSubmitRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        TestResultResponse response = politicalTypeService.saveResult(request, userDetails.getUser());
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "내 검사 결과 조회")
+    @GetMapping("/result")
+    public ResponseEntity<BaseResponse<TestResultResponse>> getMyResult(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        TestResultResponse response = politicalTypeService.getMyResult(userDetails.getUser());
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "유형별 랭킹 조회")
+    @GetMapping("/ranking")
+    public ResponseEntity<BaseResponse<RankingResponse>> getRanking() {
+        RankingResponse response = politicalTypeService.getRanking();
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "동물유형 상세 조회")
+    @GetMapping("/animals/{code}")
+    public ResponseEntity<BaseResponse<AnimalDetailResponse>> getAnimalDetail(
+            @PathVariable String code) {
+
+        AnimalDetailResponse response = politicalTypeService.getAnimalDetail(code);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "전체 참여자 수 조회")
+    @GetMapping("/participant-count")
+    public ResponseEntity<BaseResponse<Map<String, Long>>> getParticipantCount() {
+        long count = politicalTypeService.getParticipantCount();
+        return ResponseEntity.ok(BaseResponse.success(Map.of("count", count)));
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeQuestionAdminController.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeQuestionAdminController.java
@@ -1,0 +1,76 @@
+package com.graydang.app.domain.politicaltype.controller;
+
+import com.graydang.app.domain.politicaltype.dto.request.QuestionSyncRequest;
+import com.graydang.app.domain.politicaltype.dto.request.QuestionUpdateRequest;
+import com.graydang.app.domain.politicaltype.dto.response.QuestionAdminResponse;
+import com.graydang.app.domain.politicaltype.service.PoliticalTypeQuestionAdminService;
+import com.graydang.app.global.common.model.dto.BaseResponse;
+import com.graydang.app.global.common.model.enums.BaseResponseStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/political-type/questions")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Admin-PoliticalType-Question", description = "정치 유형 검사 문항 관리 API")
+public class PoliticalTypeQuestionAdminController {
+
+    private final PoliticalTypeQuestionAdminService questionAdminService;
+
+    /** 전체 문항 조회 (displayOrder 순). */
+    @Operation(summary = "문항 전체 조회")
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<QuestionAdminResponse>>> getAllQuestions() {
+        List<QuestionAdminResponse> response = questionAdminService.getAllQuestions();
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 문항 단건 조회. */
+    @Operation(summary = "문항 단건 조회")
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<QuestionAdminResponse>> getQuestion(@PathVariable Long id) {
+        QuestionAdminResponse response = questionAdminService.getQuestion(id);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 문항 단건 수정 (내용만, 순서는 sync로). */
+    @Operation(summary = "문항 단건 수정")
+    @PutMapping("/{id}")
+    public ResponseEntity<BaseResponse<QuestionAdminResponse>> updateQuestion(
+            @PathVariable Long id,
+            @Valid @RequestBody QuestionUpdateRequest request) {
+
+        QuestionAdminResponse response = questionAdminService.updateQuestion(id, request);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    /** 문항 단건 삭제 + 나머지 displayOrder 재정렬. */
+    @Operation(summary = "문항 단건 삭제")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse<Void>> deleteQuestion(@PathVariable Long id) {
+        questionAdminService.deleteQuestion(id);
+        return ResponseEntity.ok(BaseResponse.success(BaseResponseStatus.SUCCESS));
+    }
+
+    /**
+     * 문항 벌크 동기화 (추가/수정/삭제/순서변경 한 번에).
+     * 배열 순서가 곧 displayOrder.
+     * id=null → 신규, id 있음 → 수정, 기존 DB에만 있고 목록에 없음 → 삭제.
+     */
+    @Operation(summary = "문항 벌크 동기화")
+    @PutMapping("/sync")
+    public ResponseEntity<BaseResponse<List<QuestionAdminResponse>>> syncQuestions(
+            @Valid @RequestBody QuestionSyncRequest request) {
+
+        List<QuestionAdminResponse> response = questionAdminService.syncQuestions(request);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeQuestionAdminController.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/controller/PoliticalTypeQuestionAdminController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,7 +18,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/admin/political-type/questions")
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Admin-PoliticalType-Question", description = "정치 유형 검사 문항 관리 API")
 public class PoliticalTypeQuestionAdminController {
 

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/request/AnimalCreateRequest.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/request/AnimalCreateRequest.java
@@ -1,0 +1,62 @@
+package com.graydang.app.domain.politicaltype.dto.request;
+
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "동물유형 등록 요청")
+public class AnimalCreateRequest {
+
+    @NotBlank(message = "동물 코드는 필수입니다")
+    @Size(max = 30, message = "동물 코드는 30자 이하여야 합니다")
+    @Schema(description = "동물 유형 코드", example = "DOLPHIN")
+    private String code;
+
+    @NotBlank(message = "동물 이름은 필수입니다")
+    @Size(max = 20, message = "동물 이름은 20자 이하여야 합니다")
+    @Schema(description = "동물 이름", example = "돌고래")
+    private String name;
+
+
+    @Size(max = 100, message = "부제는 100자 이하여야 합니다")
+    @Schema(description = "부제", example = "정의로운 혁명가")
+    private String subtitle;
+
+    @NotBlank(message = "한줄 요약은 필수입니다")
+    @Size(max = 100, message = "한줄 요약은 100자 이하여야 합니다")
+    @Schema(description = "한줄 요약", example = "바꿔야 한다면, 지금이야!")
+    private String oneLiner;
+
+    @NotBlank(message = "상세 설명은 필수입니다")
+    @Schema(description = "상세 설명")
+    private String description;
+
+    @Schema(description = "키워드 목록", example = "[\"자유\", \"급진\", \"적극참여\"]")
+    private List<String> keywords;
+
+    @Schema(description = "대표 인물 목록", example = "[\"인물A\", \"인물B\"]")
+    private List<String> representativeFigures;
+
+
+    @NotNull(message = "변화선호 레벨은 필수입니다")
+    @Schema(description = "변화선호 레벨 (매트릭스 행)", example = "HIGH")
+    private ScoreLevel changePreferenceLevel;
+
+    @NotNull(message = "가치지향 레벨은 필수입니다")
+    @Schema(description = "가치지향 레벨 (매트릭스 열)", example = "HIGH")
+    private ScoreLevel valueOrientationLevel;
+
+    @Schema(description = "잘 맞는 유형 ID (첫 등록 시 null 가능)", example = "2")
+    private Long compatibleAnimalId;
+
+    @Schema(description = "안 맞는 유형 ID (첫 등록 시 null 가능)", example = "3")
+    private Long incompatibleAnimalId;
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/request/AnimalUpdateRequest.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/request/AnimalUpdateRequest.java
@@ -1,0 +1,61 @@
+package com.graydang.app.domain.politicaltype.dto.request;
+
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "동물유형 수정 요청")
+public class AnimalUpdateRequest {
+
+    @NotBlank(message = "동물 코드는 필수입니다")
+    @Size(max = 30, message = "동물 코드는 30자 이하여야 합니다")
+    @Schema(description = "동물 유형 코드", example = "DOLPHIN")
+    private String code;
+
+    @NotBlank(message = "동물 이름은 필수입니다")
+    @Size(max = 20, message = "동물 이름은 20자 이하여야 합니다")
+    @Schema(description = "동물 이름", example = "돌고래")
+    private String name;
+
+
+    @Schema(description = "부제", example = "정의로운 혁명가")
+    private String subtitle;
+
+    @NotBlank(message = "한줄 요약은 필수입니다")
+    @Size(max = 100, message = "한줄 요약은 100자 이하여야 합니다")
+    @Schema(description = "한줄 요약", example = "바꿔야 한다면, 지금이야!")
+    private String oneLiner;
+
+    @NotBlank(message = "상세 설명은 필수입니다")
+    @Schema(description = "상세 설명")
+    private String description;
+
+    @Schema(description = "키워드 목록", example = "[\"자유\", \"급진\", \"적극참여\"]")
+    private List<String> keywords;
+
+    @Schema(description = "대표 인물 목록", example = "[\"인물A\", \"인물B\"]")
+    private List<String> representativeFigures;
+
+
+    @NotNull(message = "변화선호 레벨은 필수입니다")
+    @Schema(description = "변화선호 레벨 (매트릭스 행)", example = "HIGH")
+    private ScoreLevel changePreferenceLevel;
+
+    @NotNull(message = "가치지향 레벨은 필수입니다")
+    @Schema(description = "가치지향 레벨 (매트릭스 열)", example = "HIGH")
+    private ScoreLevel valueOrientationLevel;
+
+    @Schema(description = "잘 맞는 유형 ID (null이면 해제)", example = "2")
+    private Long compatibleAnimalId;
+
+    @Schema(description = "안 맞는 유형 ID (null이면 해제)", example = "3")
+    private Long incompatibleAnimalId;
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/request/QuestionSyncRequest.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/request/QuestionSyncRequest.java
@@ -1,0 +1,42 @@
+package com.graydang.app.domain.politicaltype.dto.request;
+
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "문항 벌크 동기화 요청")
+public class QuestionSyncRequest {
+
+    @NotNull(message = "문항 목록은 필수입니다")
+    @Valid
+    @Schema(description = "전체 문항 리스트 (배열 순서 = displayOrder)")
+    private List<QuestionSyncItem> questions;
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "개별 문항 항목")
+    public static class QuestionSyncItem {
+
+        @Schema(description = "문항 ID (null이면 신규 생성)", example = "1")
+        private Long id;
+
+        @NotBlank(message = "문항 내용은 필수입니다")
+        @Schema(description = "문항 텍스트", example = "나는 정치 뉴스를 자주 챙겨 본다")
+        private String content;
+
+        @NotNull(message = "측정 지표는 필수입니다")
+        @Schema(description = "소속 측정 지표", example = "PARTICIPATION")
+        private MetricType metricType;
+
+        @Schema(description = "역코딩 여부", example = "false")
+        private Boolean reverseScored = false;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/request/QuestionUpdateRequest.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/request/QuestionUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.graydang.app.domain.politicaltype.dto.request;
+
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "검사 문항 수정 요청")
+public class QuestionUpdateRequest {
+
+    @NotBlank(message = "문항 내용은 필수입니다")
+    @Schema(description = "문항 텍스트", example = "나는 정치 뉴스를 자주 챙겨 본다")
+    private String content;
+
+    @NotNull(message = "측정 지표는 필수입니다")
+    @Schema(description = "소속 측정 지표", example = "PARTICIPATION")
+    private MetricType metricType;
+
+    @Schema(description = "역코딩 여부", example = "false")
+    private Boolean reverseScored = false;
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/request/TestSubmitRequest.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/request/TestSubmitRequest.java
@@ -1,0 +1,44 @@
+package com.graydang.app.domain.politicaltype.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 검사 답변 제출 요청. */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "검사 답변 제출 요청")
+public class TestSubmitRequest {
+
+    @Valid
+    @NotEmpty(message = "답변 목록은 비어 있을 수 없습니다.")
+    @Schema(description = "문항별 응답 리스트")
+    private List<AnswerItem> answers;
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Schema(description = "개별 문항 응답")
+    public static class AnswerItem {
+
+        @NotNull(message = "문항 ID는 필수입니다.")
+        @Schema(description = "문항 ID", example = "1")
+        private Long questionId;
+
+        @NotNull(message = "응답 점수는 필수입니다.")
+        @Min(value = 1, message = "응답 점수는 1 이상이어야 합니다.")
+        @Max(value = 5, message = "응답 점수는 5 이하여야 합니다.")
+        @Schema(description = "응답 점수 (1~5 리커트 척도)", example = "4")
+        private Integer score;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/response/AnimalAdminResponse.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/response/AnimalAdminResponse.java
@@ -1,0 +1,85 @@
+package com.graydang.app.domain.politicaltype.dto.response;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "동물유형 관리자 응답")
+public class AnimalAdminResponse {
+
+    @Schema(description = "동물유형 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "동물 유형 코드", example = "DOLPHIN")
+    private String code;
+
+    @Schema(description = "동물 이름", example = "돌고래")
+    private String name;
+
+
+    @Schema(description = "부제", example = "정의로운 혁명가")
+    private String subtitle;
+
+    @Schema(description = "한줄 요약", example = "바꿔야 한다면, 지금이야!")
+    private String oneLiner;
+
+    @Schema(description = "상세 설명")
+    private String description;
+
+    @Schema(description = "키워드 목록")
+    private List<String> keywords;
+
+    @Schema(description = "대표 인물 목록")
+    private List<String> representativeFigures;
+
+    @Schema(description = "이미지 URL")
+    private String imageUrl;
+
+    @Schema(description = "원본 이미지 파일명")
+    private String originalImageName;
+
+    @Schema(description = "변화선호 레벨", example = "HIGH")
+    private ScoreLevel changePreferenceLevel;
+
+    @Schema(description = "가치지향 레벨", example = "HIGH")
+    private ScoreLevel valueOrientationLevel;
+
+    @Schema(description = "잘 맞는 유형 ID")
+    private Long compatibleAnimalId;
+
+    @Schema(description = "잘 맞는 유형 이름")
+    private String compatibleAnimalName;
+
+    @Schema(description = "안 맞는 유형 ID")
+    private Long incompatibleAnimalId;
+
+    @Schema(description = "안 맞는 유형 이름")
+    private String incompatibleAnimalName;
+
+    public static AnimalAdminResponse from(PoliticalTypeAnimal animal) {
+        return AnimalAdminResponse.builder()
+                .id(animal.getId())
+                .code(animal.getCode())
+                .name(animal.getName())
+                .subtitle(animal.getSubtitle())
+                .oneLiner(animal.getOneLiner())
+                .description(animal.getDescription())
+                .keywords(animal.getKeywords())
+                .representativeFigures(animal.getRepresentativeFigures())
+                .imageUrl(animal.getImageUrl())
+                .originalImageName(animal.getOriginalImageName())
+                .changePreferenceLevel(animal.getChangePreferenceLevel())
+                .valueOrientationLevel(animal.getValueOrientationLevel())
+                .compatibleAnimalId(animal.getCompatibleAnimal() != null ? animal.getCompatibleAnimal().getId() : null)
+                .compatibleAnimalName(animal.getCompatibleAnimal() != null ? animal.getCompatibleAnimal().getName() : null)
+                .incompatibleAnimalId(animal.getIncompatibleAnimal() != null ? animal.getIncompatibleAnimal().getId() : null)
+                .incompatibleAnimalName(animal.getIncompatibleAnimal() != null ? animal.getIncompatibleAnimal().getName() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/response/AnimalDetailResponse.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/response/AnimalDetailResponse.java
@@ -1,0 +1,83 @@
+package com.graydang.app.domain.politicaltype.dto.response;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/** 동물유형 상세 조회 응답. */
+@Getter
+@Builder
+@Schema(description = "동물유형 상세 정보")
+public class AnimalDetailResponse {
+
+    @Schema(description = "동물 코드", example = "DOLPHIN")
+    private final String code;
+
+    @Schema(description = "동물 이름", example = "돌고래")
+    private final String name;
+
+    @Schema(description = "부제", example = "열정가득 이상과 변화를 쫓는 행동가형")
+    private final String subtitle;
+
+    @Schema(description = "한줄 소개", example = "바꿔야 한다면, 지금이야!")
+    private final String oneLiner;
+
+    @Schema(description = "상세 설명")
+    private final String description;
+
+    @Schema(description = "키워드")
+    private final List<String> keywords;
+
+    @Schema(description = "대표 인물")
+    private final List<String> representativeFigures;
+
+    @Schema(description = "이미지 URL")
+    private final String imageUrl;
+
+    @Schema(description = "잘 맞는 유형")
+    private final SimpleAnimalInfo compatibleAnimal;
+
+    @Schema(description = "안 맞는 유형")
+    private final SimpleAnimalInfo incompatibleAnimal;
+
+    @Getter
+    @Builder
+    @Schema(description = "상성 동물 간략 정보")
+    public static class SimpleAnimalInfo {
+        @Schema(description = "동물 코드", example = "FLYING_SQUIRREL")
+        private final String code;
+
+        @Schema(description = "동물 이름", example = "날다람쥐")
+        private final String name;
+
+        @Schema(description = "이미지 URL")
+        private final String imageUrl;
+    }
+
+    public static AnimalDetailResponse from(PoliticalTypeAnimal animal) {
+        return AnimalDetailResponse.builder()
+                .code(animal.getCode())
+                .name(animal.getName())
+                .subtitle(animal.getSubtitle())
+                .oneLiner(animal.getOneLiner())
+                .description(animal.getDescription())
+                .keywords(animal.getKeywords())
+                .representativeFigures(animal.getRepresentativeFigures())
+                .imageUrl(animal.getImageUrl())
+                .compatibleAnimal(toSimpleInfo(animal.getCompatibleAnimal()))
+                .incompatibleAnimal(toSimpleInfo(animal.getIncompatibleAnimal()))
+                .build();
+    }
+
+    private static SimpleAnimalInfo toSimpleInfo(PoliticalTypeAnimal animal) {
+        if (animal == null) return null;
+        return SimpleAnimalInfo.builder()
+                .code(animal.getCode())
+                .name(animal.getName())
+                .imageUrl(animal.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/response/QuestionAdminResponse.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/response/QuestionAdminResponse.java
@@ -1,0 +1,38 @@
+package com.graydang.app.domain.politicaltype.dto.response;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "검사 문항 관리자 응답")
+public class QuestionAdminResponse {
+
+    @Schema(description = "문항 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "문항 텍스트", example = "나는 정치 뉴스를 자주 챙겨 본다")
+    private String content;
+
+    @Schema(description = "소속 측정 지표", example = "PARTICIPATION")
+    private MetricType metricType;
+
+    @Schema(description = "역코딩 여부", example = "false")
+    private Boolean reverseScored;
+
+    @Schema(description = "표시 순서 (= 문항 번호)", example = "1")
+    private Integer displayOrder;
+
+    public static QuestionAdminResponse from(PoliticalTypeQuestion question) {
+        return QuestionAdminResponse.builder()
+                .id(question.getId())
+                .content(question.getContent())
+                .metricType(question.getMetricType())
+                .reverseScored(question.getReverseScored())
+                .displayOrder(question.getDisplayOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/response/QuestionResponse.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/response/QuestionResponse.java
@@ -1,0 +1,30 @@
+package com.graydang.app.domain.politicaltype.dto.response;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+/** 사용자용 문항 응답. metricType 등 내부 정보는 제외. */
+@Getter
+@Builder
+@Schema(description = "검사 문항 (사용자용)")
+public class QuestionResponse {
+
+    @Schema(description = "문항 ID", example = "1")
+    private final Long id;
+
+    @Schema(description = "문항 번호", example = "1")
+    private final Integer questionNumber;
+
+    @Schema(description = "문항 내용", example = "약자를 보호하는 정책이 경제 효율보다 우선되어야 한다.")
+    private final String content;
+
+    public static QuestionResponse from(PoliticalTypeQuestion question) {
+        return QuestionResponse.builder()
+                .id(question.getId())
+                .questionNumber(question.getDisplayOrder())
+                .content(question.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/response/RankingResponse.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/response/RankingResponse.java
@@ -1,0 +1,44 @@
+package com.graydang.app.domain.politicaltype.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/** 유형별 랭킹 응답. */
+@Getter
+@Builder
+@Schema(description = "유형별 랭킹")
+public class RankingResponse {
+
+    @Schema(description = "전체 참여자 수", example = "20000")
+    private final Long totalParticipants;
+
+    @Schema(description = "유형별 순위 목록 (내림차순)")
+    private final List<RankingItem> rankings;
+
+    @Getter
+    @Builder
+    @Schema(description = "랭킹 항목")
+    public static class RankingItem {
+
+        @Schema(description = "순위", example = "1")
+        private final Integer rank;
+
+        @Schema(description = "동물 코드", example = "DOLPHIN")
+        private final String animalCode;
+
+        @Schema(description = "동물 이름", example = "돌고래")
+        private final String animalName;
+
+        @Schema(description = "이미지 URL")
+        private final String imageUrl;
+
+        @Schema(description = "해당 유형 인원수", example = "5000")
+        private final Long count;
+
+        @Schema(description = "비율 (%)", example = "25.0")
+        private final Double percentage;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/dto/response/TestResultResponse.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/dto/response/TestResultResponse.java
@@ -1,0 +1,125 @@
+package com.graydang.app.domain.politicaltype.dto.response;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeTestResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/** 검사 결과 응답. */
+@Getter
+@Builder
+@Schema(description = "검사 결과")
+public class TestResultResponse {
+
+    @Schema(description = "행동유형 코드 (FLYING/JUMPING/LYING_DOWN)", example = "FLYING")
+    private final String actionStyleCode;
+
+    @Schema(description = "행동유형 한글 (수식어)", example = "날아다니는")
+    private final String actionStyleName;
+
+    @Schema(description = "동물유형 정보")
+    private final AnimalInfo animal;
+
+    @Schema(description = "참여도 평균 점수", example = "4.2")
+    private final Double participationScore;
+
+    @Schema(description = "변화선호 평균 점수", example = "3.8")
+    private final Double changePreferenceScore;
+
+    @Schema(description = "가치지향 평균 점수", example = "4.0")
+    private final Double valueOrientationScore;
+
+    @Schema(description = "결과 저장 여부 (비회원이면 false)", example = "true")
+    private final Boolean saved;
+
+    @Getter
+    @Builder
+    @Schema(description = "동물유형 상세 정보")
+    public static class AnimalInfo {
+
+        @Schema(description = "동물 코드", example = "DOLPHIN")
+        private final String code;
+
+        @Schema(description = "동물 이름", example = "돌고래")
+        private final String name;
+
+        @Schema(description = "부제", example = "열정가득 이상과 변화를 쫓는 행동가형")
+        private final String subtitle;
+
+        @Schema(description = "한줄 소개", example = "바꿔야 한다면, 지금이야!")
+        private final String oneLiner;
+
+        @Schema(description = "상세 설명")
+        private final String description;
+
+        @Schema(description = "키워드", example = "[\"자유\", \"급진\", \"적극참여\"]")
+        private final List<String> keywords;
+
+        @Schema(description = "대표 인물", example = "[\"000\", \"000\"]")
+        private final List<String> representativeFigures;
+
+        @Schema(description = "이미지 URL")
+        private final String imageUrl;
+
+        @Schema(description = "잘 맞는 유형")
+        private final CompatibleAnimalInfo compatibleAnimal;
+
+        @Schema(description = "안 맞는 유형")
+        private final CompatibleAnimalInfo incompatibleAnimal;
+
+        public static AnimalInfo from(PoliticalTypeAnimal animal) {
+            return AnimalInfo.builder()
+                    .code(animal.getCode())
+                    .name(animal.getName())
+                    .subtitle(animal.getSubtitle())
+                    .oneLiner(animal.getOneLiner())
+                    .description(animal.getDescription())
+                    .keywords(animal.getKeywords())
+                    .representativeFigures(animal.getRepresentativeFigures())
+                    .imageUrl(animal.getImageUrl())
+                    .compatibleAnimal(toCompatibleInfo(animal.getCompatibleAnimal()))
+                    .incompatibleAnimal(toCompatibleInfo(animal.getIncompatibleAnimal()))
+                    .build();
+        }
+
+        private static CompatibleAnimalInfo toCompatibleInfo(PoliticalTypeAnimal animal) {
+            if (animal == null) return null;
+            return CompatibleAnimalInfo.builder()
+                    .code(animal.getCode())
+                    .name(animal.getName())
+                    .imageUrl(animal.getImageUrl())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "상성 동물 간략 정보")
+    public static class CompatibleAnimalInfo {
+
+        @Schema(description = "동물 코드", example = "FLYING_SQUIRREL")
+        private final String code;
+
+        @Schema(description = "동물 이름", example = "날다람쥐")
+        private final String name;
+
+        @Schema(description = "이미지 URL")
+        private final String imageUrl;
+    }
+
+    /** Entity → DTO 변환. */
+    public static TestResultResponse from(PoliticalTypeTestResult result) {
+        return TestResultResponse.builder()
+                .actionStyleCode(result.getActionStyle().name())
+                .actionStyleName(result.getActionStyle().getKorean())
+                .animal(AnimalInfo.from(result.getAnimal()))
+                .participationScore(result.getParticipationScore())
+                .changePreferenceScore(result.getChangePreferenceScore())
+                .valueOrientationScore(result.getValueOrientationScore())
+                .saved(true)
+                .build();
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeAnimal.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeAnimal.java
@@ -1,0 +1,107 @@
+package com.graydang.app.domain.politicaltype.model;
+
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import com.graydang.app.global.common.converter.StringListConverter;
+import com.graydang.app.global.common.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 동물 유형 콘텐츠 (9종).
+ * 변화선호 × 가치지향 매트릭스로 결정되며, 관리자가 콘텐츠를 수정할 수 있도록 DB로 관리한다.
+ */
+@Entity
+@Table(name = "political_type_animal",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"change_preference_level", "value_orientation_level"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PoliticalTypeAnimal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 30)
+    @Comment("동물 유형 코드 (예: DOLPHIN, OWL)")
+    private String code;
+
+    @Column(nullable = false, length = 20)
+    @Comment("동물 이름 (예: 돌고래)")
+    private String name;
+
+    @Column(nullable = false, length = 10)
+    @Comment("이모지 (예: 🐬)")
+    private String emoji;
+
+    @Column(length = 100)
+    @Comment("부제 (예: 정의로운 혁명가)")
+    private String subtitle;
+
+    @Column(nullable = false, length = 100)
+    @Comment("한줄 요약 (예: 바꿔야 한다면, 지금이야!)")
+    private String oneLiner;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    @Comment("상세 설명")
+    private String description;
+
+    @Convert(converter = StringListConverter.class)
+    @Column(nullable = false, columnDefinition = "TEXT")
+    @Comment("키워드 (JSON 배열)")
+    @Builder.Default
+    private List<String> keywords = new ArrayList<>();
+
+    @Convert(converter = StringListConverter.class)
+    @Column(nullable = false, columnDefinition = "TEXT")
+    @Comment("대표 인물 (JSON 배열)")
+    @Builder.Default
+    private List<String> representativeFigures = new ArrayList<>();
+
+    @Column(length = 500)
+    @Comment("동물 캐릭터 이미지 URL")
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    @Comment("변화선호 레벨 (HIGH/MID/LOW)")
+    private ScoreLevel changePreferenceLevel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    @Comment("가치지향 레벨 (HIGH/MID/LOW)")
+    private ScoreLevel valueOrientationLevel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "compatible_animal_id")
+    @Comment("잘 맞는 유형")
+    private PoliticalTypeAnimal compatibleAnimal;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "incompatible_animal_id")
+    @Comment("안 맞는 유형")
+    private PoliticalTypeAnimal incompatibleAnimal;
+
+    public void update(String name, String emoji, String subtitle, String oneLiner,
+                       String description, List<String> keywords, List<String> representativeFigures,
+                       String imageUrl) {
+        this.name = name;
+        this.emoji = emoji;
+        this.subtitle = subtitle;
+        this.oneLiner = oneLiner;
+        this.description = description;
+        this.keywords = keywords;
+        this.representativeFigures = representativeFigures;
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateCompatibility(PoliticalTypeAnimal compatible, PoliticalTypeAnimal incompatible) {
+        this.compatibleAnimal = compatible;
+        this.incompatibleAnimal = incompatible;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeAnimal.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeAnimal.java
@@ -35,9 +35,6 @@ public class PoliticalTypeAnimal extends BaseEntity {
     @Comment("동물 이름 (예: 돌고래)")
     private String name;
 
-    @Column(nullable = false, length = 10)
-    @Comment("이모지 (예: 🐬)")
-    private String emoji;
 
     @Column(length = 100)
     @Comment("부제 (예: 정의로운 혁명가)")
@@ -67,6 +64,10 @@ public class PoliticalTypeAnimal extends BaseEntity {
     @Comment("동물 캐릭터 이미지 URL")
     private String imageUrl;
 
+    @Column(length = 255)
+    @Comment("원본 이미지 파일명")
+    private String originalImageName;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
     @Comment("변화선호 레벨 (HIGH/MID/LOW)")
@@ -87,17 +88,24 @@ public class PoliticalTypeAnimal extends BaseEntity {
     @Comment("안 맞는 유형")
     private PoliticalTypeAnimal incompatibleAnimal;
 
-    public void update(String name, String emoji, String subtitle, String oneLiner,
+    public void update(String code, String name, String subtitle, String oneLiner,
                        String description, List<String> keywords, List<String> representativeFigures,
-                       String imageUrl) {
+                       ScoreLevel changePreferenceLevel, ScoreLevel valueOrientationLevel) {
+        this.code = code;
         this.name = name;
-        this.emoji = emoji;
         this.subtitle = subtitle;
         this.oneLiner = oneLiner;
         this.description = description;
         this.keywords = keywords;
         this.representativeFigures = representativeFigures;
+        this.changePreferenceLevel = changePreferenceLevel;
+        this.valueOrientationLevel = valueOrientationLevel;
+    }
+
+    /** 이미지 교체. 기존 S3 삭제는 Service에서 처리. */
+    public void updateImage(String imageUrl, String originalImageName) {
         this.imageUrl = imageUrl;
+        this.originalImageName = originalImageName;
     }
 
     public void updateCompatibility(PoliticalTypeAnimal compatible, PoliticalTypeAnimal incompatible) {

--- a/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeQuestion.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeQuestion.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.Comment;
 /**
  * 정치 유형 검사 문항.
  * 각 문항은 하나의 측정 지표(MetricType)에 소속되며, 역코딩 여부를 가진다.
+ * displayOrder가 화면 표시 순서이자 문항 번호 역할을 겸한다.
  */
 @Entity
 @Table(name = "political_type_question")
@@ -21,10 +22,6 @@ public class PoliticalTypeQuestion extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(nullable = false)
-    @Comment("문항 번호")
-    private Integer questionNumber;
 
     @Column(nullable = false, length = 500)
     @Comment("문항 텍스트")
@@ -41,13 +38,18 @@ public class PoliticalTypeQuestion extends BaseEntity {
     private Boolean reverseScored = false;
 
     @Column(nullable = false)
-    @Comment("화면 표시 순서")
+    @Comment("화면 표시 순서 (1부터 시작, 문항 번호 겸용)")
     private Integer displayOrder;
 
-    public void update(String content, MetricType metricType, Boolean reverseScored, Integer displayOrder) {
+    /** 문항 내용 수정. */
+    public void update(String content, MetricType metricType, Boolean reverseScored) {
         this.content = content;
         this.metricType = metricType;
         this.reverseScored = reverseScored;
+    }
+
+    /** displayOrder 변경. */
+    public void updateDisplayOrder(Integer displayOrder) {
         this.displayOrder = displayOrder;
     }
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeQuestion.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeQuestion.java
@@ -1,0 +1,53 @@
+package com.graydang.app.domain.politicaltype.model;
+
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import com.graydang.app.global.common.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+/**
+ * 정치 유형 검사 문항.
+ * 각 문항은 하나의 측정 지표(MetricType)에 소속되며, 역코딩 여부를 가진다.
+ */
+@Entity
+@Table(name = "political_type_question")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PoliticalTypeQuestion extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Comment("문항 번호")
+    private Integer questionNumber;
+
+    @Column(nullable = false, length = 500)
+    @Comment("문항 텍스트")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    @Comment("소속 측정 지표")
+    private MetricType metricType;
+
+    @Column(nullable = false)
+    @Comment("역코딩 여부 (true면 6-점수로 변환)")
+    @Builder.Default
+    private Boolean reverseScored = false;
+
+    @Column(nullable = false)
+    @Comment("화면 표시 순서")
+    private Integer displayOrder;
+
+    public void update(String content, MetricType metricType, Boolean reverseScored, Integer displayOrder) {
+        this.content = content;
+        this.metricType = metricType;
+        this.reverseScored = reverseScored;
+        this.displayOrder = displayOrder;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeTestResult.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/model/PoliticalTypeTestResult.java
@@ -1,0 +1,65 @@
+package com.graydang.app.domain.politicaltype.model;
+
+import com.graydang.app.domain.politicaltype.model.enums.ActionStyle;
+import com.graydang.app.domain.user.model.User;
+import com.graydang.app.global.common.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+/**
+ * 유저 정치 유형 검사 결과.
+ * 유저당 최신 1건만 유지하며, 재검사 시 기존 결과를 덮어쓴다.
+ */
+@Entity
+@Table(name = "political_type_test_result")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PoliticalTypeTestResult extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @Comment("검사를 수행한 유저")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Comment("행동유형 (FLYING/JUMPING/LYING_DOWN)")
+    private ActionStyle actionStyle;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "animal_id", nullable = false)
+    @Comment("동물유형 (FK)")
+    private PoliticalTypeAnimal animal;
+
+    @Column(nullable = false)
+    @Comment("참여도 평균 점수")
+    private Double participationScore;
+
+    @Column(nullable = false)
+    @Comment("변화선호 평균 점수")
+    private Double changePreferenceScore;
+
+    @Column(nullable = false)
+    @Comment("가치지향 평균 점수")
+    private Double valueOrientationScore;
+
+    /**
+     * 재검사 시 결과를 갱신한다.
+     */
+    public void updateResult(ActionStyle actionStyle, PoliticalTypeAnimal animal,
+                             double participationScore, double changePreferenceScore,
+                             double valueOrientationScore) {
+        this.actionStyle = actionStyle;
+        this.animal = animal;
+        this.participationScore = participationScore;
+        this.changePreferenceScore = changePreferenceScore;
+        this.valueOrientationScore = valueOrientationScore;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/model/enums/ActionStyle.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/model/enums/ActionStyle.java
@@ -1,0 +1,37 @@
+package com.graydang.app.domain.politicaltype.model.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 행동유형 — 참여도(PARTICIPATION) 평균 점수 기준으로 판정.
+ * 최종 결과에서 동물유형 앞에 수식어로 붙는다. (예: "날아다니는 돌고래")
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ActionStyle {
+
+    FLYING("날아다니는", "정치 참여도가 높고 적극적으로 행동하는 유형", 3.5),
+    JUMPING("뛰어다니는", "정치에 적당한 관심을 가지고 가끔 행동하는 유형", 2.5),
+    LYING_DOWN("누워있는", "정치에 관심이 적고 소극적인 유형", 0.0);
+
+    private final String korean;
+    private final String description;
+    private final double minScore;
+
+    /**
+     * 참여도 평균 점수로 행동유형을 판정한다.
+     *
+     * @param participationAverage 참여도 지표의 평균 점수 (1.0 ~ 5.0)
+     * @return 해당하는 ActionStyle
+     */
+    public static ActionStyle fromScore(double participationAverage) {
+        if (participationAverage >= FLYING.minScore) {
+            return FLYING;
+        }
+        if (participationAverage >= JUMPING.minScore) {
+            return JUMPING;
+        }
+        return LYING_DOWN;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/model/enums/MetricType.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/model/enums/MetricType.java
@@ -1,0 +1,20 @@
+package com.graydang.app.domain.politicaltype.model.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 정치 유형 검사 측정 지표.
+ * 15문항을 3개 그룹(각 5문항)으로 분류하며, 점수 계산 시 그룹핑 기준으로 사용된다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum MetricType {
+
+    PARTICIPATION("참여도", "정치에 대한 관심과 실제 행동 수준"),
+    CHANGE_PREFERENCE("변화선호", "사회 변화와 개혁을 얼마나 선호하는지"),
+    VALUE_ORIENTATION("가치지향", "진보–보수 중 어떤 가치에 가까운지");
+
+    private final String korean;
+    private final String description;
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/model/enums/ScoreLevel.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/model/enums/ScoreLevel.java
@@ -1,0 +1,36 @@
+package com.graydang.app.domain.politicaltype.model.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 점수 레벨 — 변화선호/가치지향 평균 점수를 3단계로 분류.
+ * Animal 매트릭스 조회 시 행(변화선호)과 열(가치지향)의 키로 사용된다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ScoreLevel {
+
+    HIGH("높음", 3.5),
+    MID("중간", 2.5),
+    LOW("낮음", 0.0);
+
+    private final String korean;
+    private final double minScore;
+
+    /**
+     * 평균 점수를 3단계 레벨로 변환한다.
+     *
+     * @param average 지표 평균 점수 (1.0 ~ 5.0)
+     * @return 해당하는 ScoreLevel
+     */
+    public static ScoreLevel fromScore(double average) {
+        if (average >= HIGH.minScore) {
+            return HIGH;
+        }
+        if (average >= MID.minScore) {
+            return MID;
+        }
+        return LOW;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeAnimalRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeAnimalRepository.java
@@ -1,6 +1,7 @@
 package com.graydang.app.domain.politicaltype.repository;
 
 import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +18,11 @@ public interface PoliticalTypeAnimalRepository {
     List<PoliticalTypeAnimal> findAll();
 
     void deleteById(Long id);
+
+    /** 변화선호 × 가치지향 매트릭스 조합으로 동물유형 조회. */
+    Optional<PoliticalTypeAnimal> findByChangePreferenceLevelAndValueOrientationLevel(
+            ScoreLevel changePreferenceLevel, ScoreLevel valueOrientationLevel);
+
+    /** 동물 코드(DOLPHIN 등)로 조회. */
+    Optional<PoliticalTypeAnimal> findByCode(String code);
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeAnimalRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeAnimalRepository.java
@@ -1,7 +1,20 @@
 package com.graydang.app.domain.politicaltype.repository;
 
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+
+import java.util.List;
+import java.util.Optional;
+
 /**
  * 동물 유형 콘텐츠 Repository 인터페이스.
  */
 public interface PoliticalTypeAnimalRepository {
+
+    PoliticalTypeAnimal save(PoliticalTypeAnimal animal);
+
+    Optional<PoliticalTypeAnimal> findById(Long id);
+
+    List<PoliticalTypeAnimal> findAll();
+
+    void deleteById(Long id);
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeAnimalRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeAnimalRepository.java
@@ -1,0 +1,7 @@
+package com.graydang.app.domain.politicaltype.repository;
+
+/**
+ * 동물 유형 콘텐츠 Repository 인터페이스.
+ */
+public interface PoliticalTypeAnimalRepository {
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeQuestionRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeQuestionRepository.java
@@ -1,0 +1,8 @@
+package com.graydang.app.domain.politicaltype.repository;
+
+/**
+ * 정치 유형 검사 문항 Repository 인터페이스.
+ * Service 계층은 이 인터페이스에만 의존하며, 구현체는 infra 계층에서 결정한다.
+ */
+public interface PoliticalTypeQuestionRepository {
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeQuestionRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeQuestionRepository.java
@@ -1,8 +1,24 @@
 package com.graydang.app.domain.politicaltype.repository;
 
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+
+import java.util.List;
+import java.util.Optional;
+
 /**
  * 정치 유형 검사 문항 Repository 인터페이스.
- * Service 계층은 이 인터페이스에만 의존하며, 구현체는 infra 계층에서 결정한다.
  */
 public interface PoliticalTypeQuestionRepository {
+
+    PoliticalTypeQuestion save(PoliticalTypeQuestion question);
+
+    Optional<PoliticalTypeQuestion> findById(Long id);
+
+    List<PoliticalTypeQuestion> findAllByOrderByDisplayOrderAsc();
+
+    List<PoliticalTypeQuestion> findAll();
+
+    void deleteById(Long id);
+
+    void deleteAllById(List<Long> ids);
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeTestResultRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeTestResultRepository.java
@@ -1,0 +1,7 @@
+package com.graydang.app.domain.politicaltype.repository;
+
+/**
+ * 유저 검사 결과 Repository 인터페이스.
+ */
+public interface PoliticalTypeTestResultRepository {
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeTestResultRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/PoliticalTypeTestResultRepository.java
@@ -1,7 +1,24 @@
 package com.graydang.app.domain.politicaltype.repository;
 
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeTestResult;
+import com.graydang.app.domain.user.model.User;
+
+import java.util.List;
+import java.util.Optional;
+
 /**
  * 유저 검사 결과 Repository 인터페이스.
  */
 public interface PoliticalTypeTestResultRepository {
+
+    PoliticalTypeTestResult save(PoliticalTypeTestResult result);
+
+    /** 유저의 검사 결과 조회. 유저당 최대 1건. */
+    Optional<PoliticalTypeTestResult> findByUser(User user);
+
+    /** 전체 검사 참여자 수 (인트로 화면 표시용). */
+    long count();
+
+    /** 동물유형별 참여자 집계 (랭킹용). Object[0]=animalId(Long), Object[1]=count(Long). */
+    List<Object[]> countByAnimalGroupBy();
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeAnimalRepositoryImpl.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeAnimalRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.graydang.app.domain.politicaltype.repository.impl;
+
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeAnimalRepository;
+import com.graydang.app.domain.politicaltype.repository.jpa.PoliticalTypeAnimalJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PoliticalTypeAnimalRepositoryImpl implements PoliticalTypeAnimalRepository {
+
+    private final PoliticalTypeAnimalJpaRepository jpaRepository;
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeAnimalRepositoryImpl.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeAnimalRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.graydang.app.domain.politicaltype.repository.impl;
 
 import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
 import com.graydang.app.domain.politicaltype.repository.PoliticalTypeAnimalRepository;
 import com.graydang.app.domain.politicaltype.repository.jpa.PoliticalTypeAnimalJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +34,17 @@ public class PoliticalTypeAnimalRepositoryImpl implements PoliticalTypeAnimalRep
     @Override
     public void deleteById(Long id) {
         jpaRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<PoliticalTypeAnimal> findByChangePreferenceLevelAndValueOrientationLevel(
+            ScoreLevel changePreferenceLevel, ScoreLevel valueOrientationLevel) {
+        return jpaRepository.findByChangePreferenceLevelAndValueOrientationLevel(
+                changePreferenceLevel, valueOrientationLevel);
+    }
+
+    @Override
+    public Optional<PoliticalTypeAnimal> findByCode(String code) {
+        return jpaRepository.findByCode(code);
     }
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeAnimalRepositoryImpl.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeAnimalRepositoryImpl.java
@@ -1,13 +1,37 @@
 package com.graydang.app.domain.politicaltype.repository.impl;
 
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
 import com.graydang.app.domain.politicaltype.repository.PoliticalTypeAnimalRepository;
 import com.graydang.app.domain.politicaltype.repository.jpa.PoliticalTypeAnimalJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class PoliticalTypeAnimalRepositoryImpl implements PoliticalTypeAnimalRepository {
 
     private final PoliticalTypeAnimalJpaRepository jpaRepository;
+
+    @Override
+    public PoliticalTypeAnimal save(PoliticalTypeAnimal animal) {
+        return jpaRepository.save(animal);
+    }
+
+    @Override
+    public Optional<PoliticalTypeAnimal> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<PoliticalTypeAnimal> findAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeQuestionRepositoryImpl.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeQuestionRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.graydang.app.domain.politicaltype.repository.impl;
+
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeQuestionRepository;
+import com.graydang.app.domain.politicaltype.repository.jpa.PoliticalTypeQuestionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PoliticalTypeQuestionRepositoryImpl implements PoliticalTypeQuestionRepository {
+
+    private final PoliticalTypeQuestionJpaRepository jpaRepository;
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeQuestionRepositoryImpl.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeQuestionRepositoryImpl.java
@@ -1,13 +1,47 @@
 package com.graydang.app.domain.politicaltype.repository.impl;
 
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
 import com.graydang.app.domain.politicaltype.repository.PoliticalTypeQuestionRepository;
 import com.graydang.app.domain.politicaltype.repository.jpa.PoliticalTypeQuestionJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class PoliticalTypeQuestionRepositoryImpl implements PoliticalTypeQuestionRepository {
 
     private final PoliticalTypeQuestionJpaRepository jpaRepository;
+
+    @Override
+    public PoliticalTypeQuestion save(PoliticalTypeQuestion question) {
+        return jpaRepository.save(question);
+    }
+
+    @Override
+    public Optional<PoliticalTypeQuestion> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<PoliticalTypeQuestion> findAllByOrderByDisplayOrderAsc() {
+        return jpaRepository.findAllByOrderByDisplayOrderAsc();
+    }
+
+    @Override
+    public List<PoliticalTypeQuestion> findAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaRepository.deleteById(id);
+    }
+
+    @Override
+    public void deleteAllById(List<Long> ids) {
+        jpaRepository.deleteAllById(ids);
+    }
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeTestResultRepositoryImpl.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeTestResultRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.graydang.app.domain.politicaltype.repository.impl;
+
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeTestResultRepository;
+import com.graydang.app.domain.politicaltype.repository.jpa.PoliticalTypeTestResultJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PoliticalTypeTestResultRepositoryImpl implements PoliticalTypeTestResultRepository {
+
+    private final PoliticalTypeTestResultJpaRepository jpaRepository;
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeTestResultRepositoryImpl.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/impl/PoliticalTypeTestResultRepositoryImpl.java
@@ -1,13 +1,38 @@
 package com.graydang.app.domain.politicaltype.repository.impl;
 
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeTestResult;
 import com.graydang.app.domain.politicaltype.repository.PoliticalTypeTestResultRepository;
 import com.graydang.app.domain.politicaltype.repository.jpa.PoliticalTypeTestResultJpaRepository;
+import com.graydang.app.domain.user.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class PoliticalTypeTestResultRepositoryImpl implements PoliticalTypeTestResultRepository {
 
     private final PoliticalTypeTestResultJpaRepository jpaRepository;
+
+    @Override
+    public PoliticalTypeTestResult save(PoliticalTypeTestResult result) {
+        return jpaRepository.save(result);
+    }
+
+    @Override
+    public Optional<PoliticalTypeTestResult> findByUser(User user) {
+        return jpaRepository.findByUser(user);
+    }
+
+    @Override
+    public long count() {
+        return jpaRepository.count();
+    }
+
+    @Override
+    public List<Object[]> countByAnimalGroupBy() {
+        return jpaRepository.countByAnimalGroupBy();
+    }
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeAnimalJpaRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeAnimalJpaRepository.java
@@ -1,7 +1,15 @@
 package com.graydang.app.domain.politicaltype.repository.jpa;
 
 import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PoliticalTypeAnimalJpaRepository extends JpaRepository<PoliticalTypeAnimal, Long> {
+
+    Optional<PoliticalTypeAnimal> findByChangePreferenceLevelAndValueOrientationLevel(
+            ScoreLevel changePreferenceLevel, ScoreLevel valueOrientationLevel);
+
+    Optional<PoliticalTypeAnimal> findByCode(String code);
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeAnimalJpaRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeAnimalJpaRepository.java
@@ -1,0 +1,7 @@
+package com.graydang.app.domain.politicaltype.repository.jpa;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PoliticalTypeAnimalJpaRepository extends JpaRepository<PoliticalTypeAnimal, Long> {
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeQuestionJpaRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeQuestionJpaRepository.java
@@ -1,0 +1,7 @@
+package com.graydang.app.domain.politicaltype.repository.jpa;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PoliticalTypeQuestionJpaRepository extends JpaRepository<PoliticalTypeQuestion, Long> {
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeQuestionJpaRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeQuestionJpaRepository.java
@@ -3,5 +3,9 @@ package com.graydang.app.domain.politicaltype.repository.jpa;
 import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PoliticalTypeQuestionJpaRepository extends JpaRepository<PoliticalTypeQuestion, Long> {
+
+    List<PoliticalTypeQuestion> findAllByOrderByDisplayOrderAsc();
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeTestResultJpaRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeTestResultJpaRepository.java
@@ -1,0 +1,7 @@
+package com.graydang.app.domain.politicaltype.repository.jpa;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeTestResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PoliticalTypeTestResultJpaRepository extends JpaRepository<PoliticalTypeTestResult, Long> {
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeTestResultJpaRepository.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/repository/jpa/PoliticalTypeTestResultJpaRepository.java
@@ -1,7 +1,21 @@
 package com.graydang.app.domain.politicaltype.repository.jpa;
 
 import com.graydang.app.domain.politicaltype.model.PoliticalTypeTestResult;
+import com.graydang.app.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface PoliticalTypeTestResultJpaRepository extends JpaRepository<PoliticalTypeTestResult, Long> {
+
+    Optional<PoliticalTypeTestResult> findByUser(User user);
+
+    /**
+     * 동물유형별 검사 결과 집계 (랭킹용).
+     * animal_id와 count를 함께 반환한다.
+     */
+    @Query("SELECT r.animal.id, COUNT(r) FROM PoliticalTypeTestResult r GROUP BY r.animal.id ORDER BY COUNT(r) DESC")
+    List<Object[]> countByAnimalGroupBy();
 }

--- a/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeAnimalAdminService.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeAnimalAdminService.java
@@ -1,0 +1,154 @@
+package com.graydang.app.domain.politicaltype.service;
+
+import com.graydang.app.domain.politicaltype.dto.request.AnimalCreateRequest;
+import com.graydang.app.domain.politicaltype.dto.request.AnimalUpdateRequest;
+import com.graydang.app.domain.politicaltype.dto.response.AnimalAdminResponse;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeAnimalRepository;
+import com.graydang.app.global.common.exception.BusinessException;
+import com.graydang.app.global.common.model.enums.BaseResponseStatus;
+import com.graydang.app.global.s3.model.ImagePrefix;
+import com.graydang.app.global.s3.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PoliticalTypeAnimalAdminService {
+
+    private final PoliticalTypeAnimalRepository animalRepository;
+    private final ImageService imageService;
+
+    /**
+     * 동물유형 콘텐츠 등록.
+     * 이미지가 포함된 경우 S3 업로드 후 URL 저장. 실패 시 보상 삭제.
+     */
+    @Transactional
+    public AnimalAdminResponse createAnimal(AnimalCreateRequest request, MultipartFile image) {
+        PoliticalTypeAnimal compatible = resolveAnimal(request.getCompatibleAnimalId());
+        PoliticalTypeAnimal incompatible = resolveAnimal(request.getIncompatibleAnimalId());
+
+        String imageUrl = null;
+        String originalName = null;
+
+        // S3 업로드 → DB 저장. DB 실패 시 S3 보상 삭제
+        if (image != null && !image.isEmpty()) {
+            imageUrl = imageService.upload(image, ImagePrefix.POLITICAL_TYPE_ANIMAL);
+            originalName = image.getOriginalFilename();
+        }
+
+        try {
+            PoliticalTypeAnimal animal = PoliticalTypeAnimal.builder()
+                    .code(request.getCode())
+                    .name(request.getName())
+                    .subtitle(request.getSubtitle())
+                    .oneLiner(request.getOneLiner())
+                    .description(request.getDescription())
+                    .keywords(request.getKeywords())
+                    .representativeFigures(request.getRepresentativeFigures())
+                    .imageUrl(imageUrl)
+                    .originalImageName(originalName)
+                    .changePreferenceLevel(request.getChangePreferenceLevel())
+                    .valueOrientationLevel(request.getValueOrientationLevel())
+                    .compatibleAnimal(compatible)
+                    .incompatibleAnimal(incompatible)
+                    .build();
+
+            return AnimalAdminResponse.from(animalRepository.save(animal));
+        } catch (Exception e) {
+            if (imageUrl != null) {
+                log.warn("DB 저장 실패로 S3 이미지 보상 삭제. url={}", imageUrl);
+                imageService.delete(imageUrl);
+            }
+            throw e;
+        }
+    }
+
+    /** 전체 동물유형 조회. */
+    public List<AnimalAdminResponse> getAllAnimals() {
+        return animalRepository.findAll().stream()
+                .map(AnimalAdminResponse::from)
+                .toList();
+    }
+
+    /** 동물유형 단건 조회. */
+    public AnimalAdminResponse getAnimal(Long id) {
+        PoliticalTypeAnimal animal = findAnimalOrThrow(id);
+        return AnimalAdminResponse.from(animal);
+    }
+
+    /** 동물유형 콘텐츠 수정 (이미지 제외). */
+    @Transactional
+    public AnimalAdminResponse updateAnimal(Long id, AnimalUpdateRequest request) {
+        PoliticalTypeAnimal animal = findAnimalOrThrow(id);
+        PoliticalTypeAnimal compatible = resolveAnimal(request.getCompatibleAnimalId());
+        PoliticalTypeAnimal incompatible = resolveAnimal(request.getIncompatibleAnimalId());
+
+        animal.update(
+                request.getCode(),
+                request.getName(),
+                request.getSubtitle(),
+                request.getOneLiner(),
+                request.getDescription(),
+                request.getKeywords(),
+                request.getRepresentativeFigures(),
+                request.getChangePreferenceLevel(),
+                request.getValueOrientationLevel()
+        );
+        animal.updateCompatibility(compatible, incompatible);
+
+        return AnimalAdminResponse.from(animal);
+    }
+
+    /**
+     * 동물유형 이미지 교체.
+     * 기존 이미지가 있으면 S3에서 삭제 후 새 이미지 업로드.
+     */
+    @Transactional
+    public AnimalAdminResponse updateAnimalImage(Long id, MultipartFile image) {
+        PoliticalTypeAnimal animal = findAnimalOrThrow(id);
+
+        // 기존 이미지 S3 삭제
+        if (animal.getImageUrl() != null) {
+            imageService.delete(animal.getImageUrl());
+        }
+
+        // 새 이미지 업로드
+        String newImageUrl = imageService.upload(image, ImagePrefix.POLITICAL_TYPE_ANIMAL);
+        animal.updateImage(newImageUrl, image.getOriginalFilename());
+
+        return AnimalAdminResponse.from(animal);
+    }
+
+    /** 동물유형 삭제. S3 이미지도 함께 삭제. */
+    @Transactional
+    public void deleteAnimal(Long id) {
+        PoliticalTypeAnimal animal = findAnimalOrThrow(id);
+
+        // S3 이미지 삭제
+        if (animal.getImageUrl() != null) {
+            imageService.delete(animal.getImageUrl());
+        }
+
+        animalRepository.deleteById(id);
+    }
+
+    private PoliticalTypeAnimal findAnimalOrThrow(Long id) {
+        return animalRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(BaseResponseStatus.POLITICAL_TYPE_ANIMAL_NOT_FOUND));
+    }
+
+    private PoliticalTypeAnimal resolveAnimal(Long animalId) {
+        if (animalId == null) {
+            return null;
+        }
+        return findAnimalOrThrow(animalId);
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeAnimalAdminService.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeAnimalAdminService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -21,6 +22,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@PreAuthorize("hasRole('ADMIN')")
 public class PoliticalTypeAnimalAdminService {
 
     private final PoliticalTypeAnimalRepository animalRepository;

--- a/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeCalculator.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeCalculator.java
@@ -1,0 +1,52 @@
+package com.graydang.app.domain.politicaltype.service;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import com.graydang.app.domain.politicaltype.model.enums.ActionStyle;
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** 정치 유형 검사 점수 계산기. */
+@Component
+public class PoliticalTypeCalculator {
+
+    private static final int REVERSE_SCORE_BASE = 6;
+
+    /**
+     * 지표별 평균 점수를 계산한다. 역코딩 적용 후 MetricType별 그룹핑.
+     *
+     * @param answerMap  문항ID → 응답 점수
+     * @param questions  전체 문항 목록
+     * @return 지표별 평균 점수
+     */
+    public Map<MetricType, Double> calculateMetricScores(Map<Long, Integer> answerMap,
+                                                         List<PoliticalTypeQuestion> questions) {
+        return questions.stream()
+                .collect(Collectors.groupingBy(
+                        PoliticalTypeQuestion::getMetricType,
+                        Collectors.averagingDouble(q -> applyReverseScoring(q, answerMap.get(q.getId())))
+                ));
+    }
+
+    /** 참여도 평균 점수로 행동유형을 판정한다. */
+    public ActionStyle determineActionStyle(double participationAverage) {
+        return ActionStyle.fromScore(participationAverage);
+    }
+
+    /** 지표 평균 점수를 3단계 레벨(HIGH/MID/LOW)로 변환한다. */
+    public ScoreLevel determineScoreLevel(double average) {
+        return ScoreLevel.fromScore(average);
+    }
+
+    /** 역코딩 적용. reverseScored 문항은 REVERSE_SCORE_BASE - rawScore. */
+    private int applyReverseScoring(PoliticalTypeQuestion question, int rawScore) {
+        if (Boolean.TRUE.equals(question.getReverseScored())) {
+            return REVERSE_SCORE_BASE - rawScore;
+        }
+        return rawScore;
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeQuestionAdminService.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeQuestionAdminService.java
@@ -11,6 +11,7 @@ import com.graydang.app.global.common.model.enums.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +22,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@PreAuthorize("hasRole('ADMIN')")
 public class PoliticalTypeQuestionAdminService {
 
     private final PoliticalTypeQuestionRepository questionRepository;

--- a/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeQuestionAdminService.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeQuestionAdminService.java
@@ -1,0 +1,139 @@
+package com.graydang.app.domain.politicaltype.service;
+
+import com.graydang.app.domain.politicaltype.dto.request.QuestionSyncRequest;
+import com.graydang.app.domain.politicaltype.dto.request.QuestionSyncRequest.QuestionSyncItem;
+import com.graydang.app.domain.politicaltype.dto.request.QuestionUpdateRequest;
+import com.graydang.app.domain.politicaltype.dto.response.QuestionAdminResponse;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeQuestionRepository;
+import com.graydang.app.global.common.exception.BusinessException;
+import com.graydang.app.global.common.model.enums.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PoliticalTypeQuestionAdminService {
+
+    private final PoliticalTypeQuestionRepository questionRepository;
+
+    /** 전체 문항 조회 (displayOrder 순). */
+    public List<QuestionAdminResponse> getAllQuestions() {
+        return questionRepository.findAllByOrderByDisplayOrderAsc().stream()
+                .map(QuestionAdminResponse::from)
+                .toList();
+    }
+
+    /** 문항 단건 조회. */
+    public QuestionAdminResponse getQuestion(Long id) {
+        PoliticalTypeQuestion question = findQuestionOrThrow(id);
+        return QuestionAdminResponse.from(question);
+    }
+
+    /** 문항 단건 수정 (내용만, 순서 변경 없음). */
+    @Transactional
+    public QuestionAdminResponse updateQuestion(Long id, QuestionUpdateRequest request) {
+        PoliticalTypeQuestion question = findQuestionOrThrow(id);
+
+        question.update(
+                request.getContent(),
+                request.getMetricType(),
+                request.getReverseScored()
+        );
+
+        return QuestionAdminResponse.from(question);
+    }
+
+    /**
+     * 문항 단건 삭제 + 나머지 문항 displayOrder 재정렬.
+     * 삭제된 문항 이후의 문항들을 앞으로 당긴다.
+     */
+    @Transactional
+    public void deleteQuestion(Long id) {
+        PoliticalTypeQuestion target = findQuestionOrThrow(id);
+        int deletedOrder = target.getDisplayOrder();
+
+        questionRepository.deleteById(id);
+
+        // 삭제된 순서 이후 문항들 displayOrder -1
+        List<PoliticalTypeQuestion> remainingQuestions = questionRepository.findAllByOrderByDisplayOrderAsc();
+        for (PoliticalTypeQuestion q : remainingQuestions) {
+            if (q.getDisplayOrder() > deletedOrder) {
+                q.updateDisplayOrder(q.getDisplayOrder() - 1);
+            }
+        }
+    }
+
+    /**
+     * 문항 벌크 동기화.
+     * - 배열에 id=null인 항목 → 신규 생성
+     * - 배열에 id가 있는 항목 → 내용 업데이트
+     * - DB에 있지만 배열에 없는 항목 → 삭제
+     * - 배열 순서(index) → displayOrder 자동 부여
+     */
+    @Transactional
+    public List<QuestionAdminResponse> syncQuestions(QuestionSyncRequest request) {
+        List<QuestionSyncItem> items = request.getQuestions();
+
+        // 기존 문항 Map
+        Map<Long, PoliticalTypeQuestion> existingMap = questionRepository.findAll().stream()
+                .collect(Collectors.toMap(PoliticalTypeQuestion::getId, q -> q));
+
+        // 요청에 포함된 기존 ID 수집
+        Set<Long> requestedIds = items.stream()
+                .map(QuestionSyncItem::getId)
+                .filter(id -> id != null)
+                .collect(Collectors.toSet());
+
+        // DB에만 있고 요청에 없는 문항 → 삭제
+        List<Long> toDelete = existingMap.keySet().stream()
+                .filter(id -> !requestedIds.contains(id))
+                .toList();
+        if (!toDelete.isEmpty()) {
+            questionRepository.deleteAllById(toDelete);
+        }
+
+        // 생성/수정 + displayOrder 부여
+        List<QuestionAdminResponse> results = new ArrayList<>();
+        for (int i = 0; i < items.size(); i++) {
+            QuestionSyncItem item = items.get(i);
+            int displayOrder = i + 1;
+
+            if (item.getId() == null) {
+                // 신규 생성
+                PoliticalTypeQuestion newQuestion = PoliticalTypeQuestion.builder()
+                        .content(item.getContent())
+                        .metricType(item.getMetricType())
+                        .reverseScored(item.getReverseScored() != null ? item.getReverseScored() : false)
+                        .displayOrder(displayOrder)
+                        .build();
+                results.add(QuestionAdminResponse.from(questionRepository.save(newQuestion)));
+            } else {
+                // 기존 수정
+                PoliticalTypeQuestion existing = existingMap.get(item.getId());
+                if (existing == null) {
+                    throw new BusinessException(BaseResponseStatus.POLITICAL_TYPE_QUESTION_NOT_FOUND);
+                }
+                existing.update(item.getContent(), item.getMetricType(),
+                        item.getReverseScored() != null ? item.getReverseScored() : false);
+                existing.updateDisplayOrder(displayOrder);
+                results.add(QuestionAdminResponse.from(existing));
+            }
+        }
+
+        return results;
+    }
+
+    private PoliticalTypeQuestion findQuestionOrThrow(Long id) {
+        return questionRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(BaseResponseStatus.POLITICAL_TYPE_QUESTION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeService.java
+++ b/src/main/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeService.java
@@ -1,0 +1,190 @@
+package com.graydang.app.domain.politicaltype.service;
+
+import com.graydang.app.domain.politicaltype.dto.request.TestSubmitRequest;
+import com.graydang.app.domain.politicaltype.dto.response.*;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeTestResult;
+import com.graydang.app.domain.politicaltype.model.enums.ActionStyle;
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeAnimalRepository;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeQuestionRepository;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeTestResultRepository;
+import com.graydang.app.domain.user.model.User;
+import com.graydang.app.global.common.exception.BusinessException;
+import com.graydang.app.global.common.model.enums.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** 정치유형 검사 사용자 Service. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PoliticalTypeService {
+
+    private final PoliticalTypeQuestionRepository questionRepository;
+    private final PoliticalTypeAnimalRepository animalRepository;
+    private final PoliticalTypeTestResultRepository resultRepository;
+    private final PoliticalTypeCalculator calculator;
+
+    /** 검사 문항 전체 조회 (displayOrder 순). */
+    public List<QuestionResponse> getQuestions() {
+        return questionRepository.findAllByOrderByDisplayOrderAsc().stream()
+                .map(QuestionResponse::from)
+                .toList();
+    }
+
+    /**
+     * 검사 답변 제출 → 유형 결과 계산.
+     * 회원이면 DB 저장(재검사 시 덮어쓰기), 비회원이면 결과만 반환.
+     *
+     * @param user 인증된 유저 (비회원이면 null)
+     */
+    @Transactional
+    public TestResultResponse submitTest(TestSubmitRequest request, User user) {
+        List<PoliticalTypeQuestion> questions = questionRepository.findAllByOrderByDisplayOrderAsc();
+
+        validateAnswerCount(request, questions);
+
+        Map<Long, Integer> answerMap = request.getAnswers().stream()
+                .collect(Collectors.toMap(
+                        TestSubmitRequest.AnswerItem::getQuestionId,
+                        TestSubmitRequest.AnswerItem::getScore
+                ));
+
+
+        Map<MetricType, Double> metricScores = calculator.calculateMetricScores(answerMap, questions);
+
+        double participationAvg = metricScores.getOrDefault(MetricType.PARTICIPATION, 0.0);
+        double changePreferenceAvg = metricScores.getOrDefault(MetricType.CHANGE_PREFERENCE, 0.0);
+        double valueOrientationAvg = metricScores.getOrDefault(MetricType.VALUE_ORIENTATION, 0.0);
+
+
+        ActionStyle actionStyle = calculator.determineActionStyle(participationAvg);
+
+
+        ScoreLevel changeLevel = calculator.determineScoreLevel(changePreferenceAvg);
+        ScoreLevel valueLevel = calculator.determineScoreLevel(valueOrientationAvg);
+
+        PoliticalTypeAnimal animal = animalRepository
+                .findByChangePreferenceLevelAndValueOrientationLevel(changeLevel, valueLevel)
+                .orElseThrow(() -> new BusinessException(BaseResponseStatus.POLITICAL_TYPE_ANIMAL_MAPPING_FAILED));
+
+
+        boolean saved = false;
+        if (user != null) {
+            saveOrUpdateResult(user, actionStyle, animal, participationAvg, changePreferenceAvg, valueOrientationAvg);
+            saved = true;
+        }
+
+        return buildResultResponse(actionStyle, animal, participationAvg, changePreferenceAvg, valueOrientationAvg, saved);
+    }
+
+    /** 비회원 → 로그인 후 결과 저장. 프론트 보관 답변을 재전송받아 저장. */
+    @Transactional
+    public TestResultResponse saveResult(TestSubmitRequest request, User user) {
+        return submitTest(request, user);
+    }
+
+    /** 내 검사 결과 조회. 결과가 없으면 예외 발생. */
+    public TestResultResponse getMyResult(User user) {
+        PoliticalTypeTestResult result = resultRepository.findByUser(user)
+                .orElseThrow(() -> new BusinessException(BaseResponseStatus.POLITICAL_TYPE_RESULT_NOT_FOUND));
+        return TestResultResponse.from(result);
+    }
+
+    /** 유형별 랭킹 조회. 동물유형별 인원수와 비율 반환. */
+    public RankingResponse getRanking() {
+        long totalParticipants = resultRepository.count();
+        List<Object[]> animalCounts = resultRepository.countByAnimalGroupBy();
+
+        // 최대 9종이므로 전체 로딩하여 N+1 방지
+        Map<Long, PoliticalTypeAnimal> animalMap = animalRepository.findAll().stream()
+                .collect(Collectors.toMap(PoliticalTypeAnimal::getId, a -> a));
+
+        List<RankingResponse.RankingItem> rankings = IntStream.range(0, animalCounts.size())
+                .mapToObj(i -> {
+                    Object[] row = animalCounts.get(i);
+                    Long animalId = (Long) row[0];
+                    Long count = (Long) row[1];
+                    PoliticalTypeAnimal animal = animalMap.get(animalId);
+
+                    return RankingResponse.RankingItem.builder()
+                            .rank(i + 1)
+                            .animalCode(animal != null ? animal.getCode() : "UNKNOWN")
+                            .animalName(animal != null ? animal.getName() : "알 수 없음")
+                            .imageUrl(animal != null ? animal.getImageUrl() : null)
+                            .count(count)
+                            .percentage(totalParticipants > 0
+                                    ? Math.round(count * 1000.0 / totalParticipants) / 10.0
+                                    : 0.0)
+                            .build();
+                })
+                .toList();
+
+        return RankingResponse.builder()
+                .totalParticipants(totalParticipants)
+                .rankings(rankings)
+                .build();
+    }
+
+    /** 특정 동물유형 상세 조회. @param code 동물 코드 */
+    public AnimalDetailResponse getAnimalDetail(String code) {
+        PoliticalTypeAnimal animal = animalRepository.findByCode(code)
+                .orElseThrow(() -> new BusinessException(BaseResponseStatus.POLITICAL_TYPE_ANIMAL_NOT_FOUND));
+        return AnimalDetailResponse.from(animal);
+    }
+
+    /** 전체 참여자 수 조회. */
+    public long getParticipantCount() {
+        return resultRepository.count();
+    }
+
+
+
+    private void validateAnswerCount(TestSubmitRequest request, List<PoliticalTypeQuestion> questions) {
+        if (request.getAnswers().size() != questions.size()) {
+            throw new BusinessException(BaseResponseStatus.POLITICAL_TYPE_INVALID_ANSWER_COUNT);
+        }
+    }
+
+    /** upsert: 유저당 1건 유지. */
+    private void saveOrUpdateResult(User user, ActionStyle actionStyle, PoliticalTypeAnimal animal,
+                                     double participation, double changePreference, double valueOrientation) {
+        resultRepository.findByUser(user)
+                .ifPresentOrElse(
+                        existing -> existing.updateResult(actionStyle, animal, participation, changePreference, valueOrientation),
+                        () -> resultRepository.save(PoliticalTypeTestResult.builder()
+                                .user(user)
+                                .actionStyle(actionStyle)
+                                .animal(animal)
+                                .participationScore(participation)
+                                .changePreferenceScore(changePreference)
+                                .valueOrientationScore(valueOrientation)
+                                .build())
+                );
+    }
+
+    private TestResultResponse buildResultResponse(ActionStyle actionStyle, PoliticalTypeAnimal animal,
+                                                    double participation, double changePreference,
+                                                    double valueOrientation, boolean saved) {
+        return TestResultResponse.builder()
+                .actionStyleCode(actionStyle.name())
+                .actionStyleName(actionStyle.getKorean())
+                .animal(TestResultResponse.AnimalInfo.from(animal))
+                .participationScore(participation)
+                .changePreferenceScore(changePreference)
+                .valueOrientationScore(valueOrientation)
+                .saved(saved)
+                .build();
+    }
+}

--- a/src/main/java/com/graydang/app/global/common/converter/StringListConverter.java
+++ b/src/main/java/com/graydang/app/global/common/converter/StringListConverter.java
@@ -1,0 +1,44 @@
+package com.graydang.app.global.common.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * List<String>을 JSON 문자열로 변환하는 JPA Converter.
+ * DB에는 '["값1","값2"]' 형태로 저장되고, 엔티티에서는 List<String>으로 사용된다.
+ */
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "[]";
+        }
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("List → JSON 변환 실패", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            return mapper.readValue(dbData, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("JSON → List 변환 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/graydang/app/global/common/model/enums/BaseResponseStatus.java
+++ b/src/main/java/com/graydang/app/global/common/model/enums/BaseResponseStatus.java
@@ -99,7 +99,9 @@ public enum BaseResponseStatus {
      */
     POLITICAL_TYPE_QUESTION_NOT_FOUND(false, HttpStatus.NOT_FOUND, 3501, "존재하지 않는 검사 문항입니다."),
     POLITICAL_TYPE_ANIMAL_NOT_FOUND(false, HttpStatus.NOT_FOUND, 3502, "존재하지 않는 동물 유형입니다."),
-    POLITICAL_TYPE_RESULT_NOT_FOUND(false, HttpStatus.NOT_FOUND, 3503, "검사 결과가 존재하지 않습니다.");
+    POLITICAL_TYPE_RESULT_NOT_FOUND(false, HttpStatus.NOT_FOUND, 3503, "검사 결과가 존재하지 않습니다."),
+    POLITICAL_TYPE_INVALID_ANSWER_COUNT(false, HttpStatus.BAD_REQUEST, 3504, "답변 수가 문항 수와 일치하지 않습니다."),
+    POLITICAL_TYPE_ANIMAL_MAPPING_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR, 3505, "동물유형 매핑에 실패했습니다.");
 
     private final boolean isSuccess;
     @JsonIgnore

--- a/src/main/java/com/graydang/app/global/common/model/enums/BaseResponseStatus.java
+++ b/src/main/java/com/graydang/app/global/common/model/enums/BaseResponseStatus.java
@@ -92,7 +92,14 @@ public enum BaseResponseStatus {
      * 3400: Search Keyword Exception
      */
     SEARCH_KEYWORD_NOT_FOUND(false, HttpStatus.NOT_FOUND, 3401, "존재하지 않는 검색 키워드입니다."),
-    SEARCH_KEYWORD_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST, 3402, "이미 존재하는 검색 키워드입니다.");
+    SEARCH_KEYWORD_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST, 3402, "이미 존재하는 검색 키워드입니다."),
+
+    /**
+     * 3500: Political Type Exception
+     */
+    POLITICAL_TYPE_QUESTION_NOT_FOUND(false, HttpStatus.NOT_FOUND, 3501, "존재하지 않는 검사 문항입니다."),
+    POLITICAL_TYPE_ANIMAL_NOT_FOUND(false, HttpStatus.NOT_FOUND, 3502, "존재하지 않는 동물 유형입니다."),
+    POLITICAL_TYPE_RESULT_NOT_FOUND(false, HttpStatus.NOT_FOUND, 3503, "검사 결과가 존재하지 않습니다.");
 
     private final boolean isSuccess;
     @JsonIgnore

--- a/src/main/java/com/graydang/app/global/s3/model/ImagePrefix.java
+++ b/src/main/java/com/graydang/app/global/s3/model/ImagePrefix.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum ImagePrefix {
 
     USER_PROFILE("user-profile/"),
+    POLITICAL_TYPE_ANIMAL("political-type/animal/"),
     TEST("test/"),
     DEFAULT("default/");
 

--- a/src/main/java/com/graydang/app/global/security/SecurityConfig.java
+++ b/src/main/java/com/graydang/app/global/security/SecurityConfig.java
@@ -53,6 +53,13 @@ public class SecurityConfig {
                     .requestMatchers("/swagger-ui/**", "/swagger-ui.html/**", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/actuator/**").permitAll()
 
+                    // 정치유형 검사 공개 API
+                    .requestMatchers(HttpMethod.GET, "/api/political-type/questions").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/political-type/submit").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/political-type/ranking").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/political-type/animals/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/political-type/participant-count").permitAll()
+
                     // 어드민 전용 API
                     .requestMatchers("/api/admin/**").hasRole("ADMIN")
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DATASOURCE_URL_LOCAL}

--- a/src/test/java/com/graydang/app/domain/politicaltype/model/enums/ActionStyleTest.java
+++ b/src/test/java/com/graydang/app/domain/politicaltype/model/enums/ActionStyleTest.java
@@ -1,0 +1,42 @@
+package com.graydang.app.domain.politicaltype.model.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActionStyleTest {
+
+    @Nested
+    @DisplayName("fromScore로 참여도 평균 점수를 행동유형으로 변환한다")
+    class FromScoreTest {
+
+        @Test
+        @DisplayName("3.5 이상이면 FLYING을 반환한다")
+        void fromScore_shouldReturnFlying() {
+            assertThat(ActionStyle.fromScore(3.5)).isEqualTo(ActionStyle.FLYING);
+            assertThat(ActionStyle.fromScore(5.0)).isEqualTo(ActionStyle.FLYING);
+
+            System.out.println("✅ fromScore_shouldReturnFlying 테스트 통과 - 3.5, 5.0 → FLYING");
+        }
+
+        @Test
+        @DisplayName("2.5 이상 3.5 미만이면 JUMPING을 반환한다")
+        void fromScore_shouldReturnJumping() {
+            assertThat(ActionStyle.fromScore(2.5)).isEqualTo(ActionStyle.JUMPING);
+            assertThat(ActionStyle.fromScore(3.4)).isEqualTo(ActionStyle.JUMPING);
+
+            System.out.println("✅ fromScore_shouldReturnJumping 테스트 통과 - 2.5, 3.4 → JUMPING");
+        }
+
+        @Test
+        @DisplayName("2.5 미만이면 LYING_DOWN을 반환한다")
+        void fromScore_shouldReturnLyingDown() {
+            assertThat(ActionStyle.fromScore(2.4)).isEqualTo(ActionStyle.LYING_DOWN);
+            assertThat(ActionStyle.fromScore(1.0)).isEqualTo(ActionStyle.LYING_DOWN);
+
+            System.out.println("✅ fromScore_shouldReturnLyingDown 테스트 통과 - 2.4, 1.0 → LYING_DOWN");
+        }
+    }
+}

--- a/src/test/java/com/graydang/app/domain/politicaltype/model/enums/ScoreLevelTest.java
+++ b/src/test/java/com/graydang/app/domain/politicaltype/model/enums/ScoreLevelTest.java
@@ -1,0 +1,42 @@
+package com.graydang.app.domain.politicaltype.model.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScoreLevelTest {
+
+    @Nested
+    @DisplayName("fromScore로 평균 점수를 레벨로 변환한다")
+    class FromScoreTest {
+
+        @Test
+        @DisplayName("3.5 이상이면 HIGH를 반환한다")
+        void fromScore_shouldReturnHigh() {
+            assertThat(ScoreLevel.fromScore(3.5)).isEqualTo(ScoreLevel.HIGH);
+            assertThat(ScoreLevel.fromScore(5.0)).isEqualTo(ScoreLevel.HIGH);
+
+            System.out.println("✅ fromScore_shouldReturnHigh 테스트 통과 - 3.5, 5.0 → HIGH");
+        }
+
+        @Test
+        @DisplayName("2.5 이상 3.5 미만이면 MID를 반환한다")
+        void fromScore_shouldReturnMid() {
+            assertThat(ScoreLevel.fromScore(2.5)).isEqualTo(ScoreLevel.MID);
+            assertThat(ScoreLevel.fromScore(3.4)).isEqualTo(ScoreLevel.MID);
+
+            System.out.println("✅ fromScore_shouldReturnMid 테스트 통과 - 2.5, 3.4 → MID");
+        }
+
+        @Test
+        @DisplayName("2.5 미만이면 LOW를 반환한다")
+        void fromScore_shouldReturnLow() {
+            assertThat(ScoreLevel.fromScore(2.4)).isEqualTo(ScoreLevel.LOW);
+            assertThat(ScoreLevel.fromScore(1.0)).isEqualTo(ScoreLevel.LOW);
+
+            System.out.println("✅ fromScore_shouldReturnLow 테스트 통과 - 2.4, 1.0 → LOW");
+        }
+    }
+}

--- a/src/test/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeAnimalAdminServiceTest.java
+++ b/src/test/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeAnimalAdminServiceTest.java
@@ -1,0 +1,186 @@
+package com.graydang.app.domain.politicaltype.service;
+
+import com.graydang.app.domain.politicaltype.dto.request.AnimalCreateRequest;
+import com.graydang.app.domain.politicaltype.dto.response.AnimalAdminResponse;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeAnimalRepository;
+import com.graydang.app.global.common.exception.BusinessException;
+import com.graydang.app.global.s3.model.ImagePrefix;
+import com.graydang.app.global.s3.service.ImageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class PoliticalTypeAnimalAdminServiceTest {
+
+    @InjectMocks
+    private PoliticalTypeAnimalAdminService animalAdminService;
+
+    @Mock
+    private PoliticalTypeAnimalRepository animalRepository;
+
+    @Mock
+    private ImageService imageService;
+
+    private PoliticalTypeAnimal createDolphin() {
+        return PoliticalTypeAnimal.builder()
+                .code("DOLPHIN")
+                .name("돌고래")
+                .subtitle("정의로운 혁명가")
+                .oneLiner("바꿔야 한다면, 지금이야!")
+                .description("돌고래 유형 상세 설명")
+                .keywords(List.of("자유", "급진"))
+                .representativeFigures(List.of("인물A"))
+                .imageUrl("https://s3.../dolphin.png")
+                .originalImageName("dolphin_character.png")
+                .changePreferenceLevel(ScoreLevel.HIGH)
+                .valueOrientationLevel(ScoreLevel.HIGH)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("createAnimal 동물유형 생성 시")
+    class CreateAnimalTest {
+
+        @Test
+        @DisplayName("이미지와 함께 정상 생성한다")
+        void createAnimal_withImage_shouldUploadAndCreate() {
+            PoliticalTypeAnimal dolphin = createDolphin();
+            given(animalRepository.save(any(PoliticalTypeAnimal.class))).willReturn(dolphin);
+            given(imageService.upload(any(MultipartFile.class), eq(ImagePrefix.POLITICAL_TYPE_ANIMAL)))
+                    .willReturn("https://s3.../dolphin.png");
+
+            AnimalCreateRequest request = new AnimalCreateRequest();
+            setField(request, "code", "DOLPHIN");
+            setField(request, "name", "돌고래");
+            setField(request, "oneLiner", "바꿔야 한다면, 지금이야!");
+            setField(request, "description", "돌고래 유형 상세 설명");
+            setField(request, "keywords", List.of("자유", "급진"));
+            setField(request, "representativeFigures", List.of("인물A"));
+            setField(request, "changePreferenceLevel", ScoreLevel.HIGH);
+            setField(request, "valueOrientationLevel", ScoreLevel.HIGH);
+
+            MockMultipartFile image = new MockMultipartFile(
+                    "image", "dolphin_character.png", "image/png", "fake-image".getBytes());
+
+            AnimalAdminResponse response = animalAdminService.createAnimal(request, image);
+
+            assertThat(response.getCode()).isEqualTo("DOLPHIN");
+            verify(imageService).upload(any(MultipartFile.class), eq(ImagePrefix.POLITICAL_TYPE_ANIMAL));
+            verify(animalRepository).save(any(PoliticalTypeAnimal.class));
+
+            System.out.println("✅ createAnimal (이미지 포함) 테스트 통과");
+        }
+
+        @Test
+        @DisplayName("이미지 없이도 정상 생성한다")
+        void createAnimal_withoutImage_shouldCreateWithNullImageUrl() {
+            PoliticalTypeAnimal dolphin = PoliticalTypeAnimal.builder()
+                    .code("DOLPHIN").name("돌고래").oneLiner("요약").description("설명")
+                    .changePreferenceLevel(ScoreLevel.HIGH).valueOrientationLevel(ScoreLevel.HIGH)
+                    .build();
+            given(animalRepository.save(any(PoliticalTypeAnimal.class))).willReturn(dolphin);
+
+            AnimalCreateRequest request = new AnimalCreateRequest();
+            setField(request, "code", "DOLPHIN");
+            setField(request, "name", "돌고래");
+            setField(request, "oneLiner", "요약");
+            setField(request, "description", "설명");
+            setField(request, "changePreferenceLevel", ScoreLevel.HIGH);
+            setField(request, "valueOrientationLevel", ScoreLevel.HIGH);
+
+            AnimalAdminResponse response = animalAdminService.createAnimal(request, null);
+
+            assertThat(response.getCode()).isEqualTo("DOLPHIN");
+            verify(imageService, never()).upload(any(), any());
+
+            System.out.println("✅ createAnimal (이미지 없음) 테스트 통과");
+        }
+    }
+
+    @Nested
+    @DisplayName("getAnimal 동물유형 단건 조회 시")
+    class GetAnimalTest {
+
+        @Test
+        @DisplayName("존재하는 ID면 동물유형을 반환한다")
+        void getAnimal_shouldReturnAnimal() {
+            given(animalRepository.findById(1L)).willReturn(Optional.of(createDolphin()));
+
+            AnimalAdminResponse response = animalAdminService.getAnimal(1L);
+
+            assertThat(response.getCode()).isEqualTo("DOLPHIN");
+            assertThat(response.getOriginalImageName()).isEqualTo("dolphin_character.png");
+            System.out.println("✅ getAnimal 테스트 통과 - originalImageName 포함 확인");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID면 BusinessException을 던진다")
+        void getAnimal_shouldThrowWhenNotFound() {
+            given(animalRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> animalAdminService.getAnimal(999L))
+                    .isInstanceOf(BusinessException.class);
+
+            System.out.println("✅ getAnimal_shouldThrowWhenNotFound 테스트 통과");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteAnimal 동물유형 삭제 시")
+    class DeleteAnimalTest {
+
+        @Test
+        @DisplayName("이미지가 있으면 S3 삭제 후 Entity를 삭제한다")
+        void deleteAnimal_withImage_shouldDeleteS3AndEntity() {
+            PoliticalTypeAnimal dolphin = createDolphin();
+            given(animalRepository.findById(1L)).willReturn(Optional.of(dolphin));
+
+            animalAdminService.deleteAnimal(1L);
+
+            verify(imageService).delete("https://s3.../dolphin.png");
+            verify(animalRepository).deleteById(1L);
+            System.out.println("✅ deleteAnimal 테스트 통과 - S3 이미지 삭제 + Entity 삭제");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID면 BusinessException을 던진다")
+        void deleteAnimal_shouldThrowWhenNotFound() {
+            given(animalRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> animalAdminService.deleteAnimal(999L))
+                    .isInstanceOf(BusinessException.class);
+
+            System.out.println("✅ deleteAnimal_shouldThrowWhenNotFound 테스트 통과");
+        }
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeCalculatorTest.java
+++ b/src/test/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeCalculatorTest.java
@@ -1,0 +1,158 @@
+package com.graydang.app.domain.politicaltype.service;
+
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import com.graydang.app.domain.politicaltype.model.enums.ActionStyle;
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PoliticalTypeCalculatorTest {
+
+    private final PoliticalTypeCalculator calculator = new PoliticalTypeCalculator();
+
+    private PoliticalTypeQuestion createQuestion(Long id, MetricType type, boolean reverse) {
+        PoliticalTypeQuestion q = PoliticalTypeQuestion.builder()
+                .content("테스트 문항")
+                .metricType(type)
+                .reverseScored(reverse)
+                .displayOrder(id.intValue())
+                .build();
+        setId(q, id);
+        return q;
+    }
+
+    @Nested
+    @DisplayName("calculateMetricScores 지표별 평균 점수 계산 시")
+    class CalculateMetricScoresTest {
+
+        @Test
+        @DisplayName("역코딩 없는 문항들의 평균을 정확히 계산한다")
+        void calculate_normalScoring_shouldReturnCorrectAverages() {
+            List<PoliticalTypeQuestion> questions = List.of(
+                    createQuestion(1L, MetricType.PARTICIPATION, false),
+                    createQuestion(2L, MetricType.PARTICIPATION, false),
+                    createQuestion(3L, MetricType.CHANGE_PREFERENCE, false),
+                    createQuestion(4L, MetricType.CHANGE_PREFERENCE, false),
+                    createQuestion(5L, MetricType.VALUE_ORIENTATION, false),
+                    createQuestion(6L, MetricType.VALUE_ORIENTATION, false)
+            );
+
+            // 참여도: (5+3)/2=4.0, 변화선호: (4+2)/2=3.0, 가치지향: (1+5)/2=3.0
+            Map<Long, Integer> answers = Map.of(1L, 5, 2L, 3, 3L, 4, 4L, 2, 5L, 1, 6L, 5);
+
+            Map<MetricType, Double> result = calculator.calculateMetricScores(answers, questions);
+
+            assertThat(result.get(MetricType.PARTICIPATION)).isEqualTo(4.0);
+            assertThat(result.get(MetricType.CHANGE_PREFERENCE)).isEqualTo(3.0);
+            assertThat(result.get(MetricType.VALUE_ORIENTATION)).isEqualTo(3.0);
+            System.out.println("✅ 역코딩 없는 평균 계산 테스트 통과 - 참여도:4.0, 변화선호:3.0, 가치지향:3.0");
+        }
+
+        @Test
+        @DisplayName("역코딩 문항은 6-점수로 변환 후 평균을 계산한다")
+        void calculate_reverseScoring_shouldApplyReverseFormula() {
+            List<PoliticalTypeQuestion> questions = List.of(
+                    createQuestion(1L, MetricType.PARTICIPATION, false),
+                    createQuestion(2L, MetricType.PARTICIPATION, true)   // 역코딩
+            );
+
+            // Q1: 5 (그대로), Q2: 1 → 역코딩 → 6-1=5. 평균 = (5+5)/2 = 5.0
+            Map<Long, Integer> answers = Map.of(1L, 5, 2L, 1);
+
+            Map<MetricType, Double> result = calculator.calculateMetricScores(answers, questions);
+
+            assertThat(result.get(MetricType.PARTICIPATION)).isEqualTo(5.0);
+            System.out.println("✅ 역코딩 적용 테스트 통과 - Q2(1→5), 평균 5.0");
+        }
+
+        @Test
+        @DisplayName("역코딩 중간값(3)은 변환해도 3이다")
+        void calculate_reverseMiddleScore_shouldRemainSame() {
+            List<PoliticalTypeQuestion> questions = List.of(
+                    createQuestion(1L, MetricType.VALUE_ORIENTATION, true)
+            );
+
+            // 점수 3 → 역코딩 → 6-3 = 3
+            Map<Long, Integer> answers = Map.of(1L, 3);
+
+            Map<MetricType, Double> result = calculator.calculateMetricScores(answers, questions);
+
+            assertThat(result.get(MetricType.VALUE_ORIENTATION)).isEqualTo(3.0);
+            System.out.println("✅ 역코딩 중간값(3→3) 테스트 통과");
+        }
+    }
+
+    @Nested
+    @DisplayName("determineActionStyle 행동유형 판정 시")
+    class DetermineActionStyleTest {
+
+        @Test
+        @DisplayName("3.5 이상이면 FLYING이다")
+        void determine_highScore_shouldReturnFlying() {
+            assertThat(calculator.determineActionStyle(4.2)).isEqualTo(ActionStyle.FLYING);
+            assertThat(calculator.determineActionStyle(3.5)).isEqualTo(ActionStyle.FLYING);
+            System.out.println("✅ FLYING 판정 테스트 통과 - 4.2, 3.5(경계값)");
+        }
+
+        @Test
+        @DisplayName("2.5 이상 3.5 미만이면 JUMPING이다")
+        void determine_midScore_shouldReturnJumping() {
+            assertThat(calculator.determineActionStyle(3.0)).isEqualTo(ActionStyle.JUMPING);
+            assertThat(calculator.determineActionStyle(2.5)).isEqualTo(ActionStyle.JUMPING);
+            System.out.println("✅ JUMPING 판정 테스트 통과 - 3.0, 2.5(경계값)");
+        }
+
+        @Test
+        @DisplayName("2.5 미만이면 LYING_DOWN이다")
+        void determine_lowScore_shouldReturnLyingDown() {
+            assertThat(calculator.determineActionStyle(2.4)).isEqualTo(ActionStyle.LYING_DOWN);
+            assertThat(calculator.determineActionStyle(1.0)).isEqualTo(ActionStyle.LYING_DOWN);
+            System.out.println("✅ LYING_DOWN 판정 테스트 통과 - 2.4, 1.0");
+        }
+    }
+
+    @Nested
+    @DisplayName("determineScoreLevel 레벨 판정 시")
+    class DetermineScoreLevelTest {
+
+        @Test
+        @DisplayName("3.5 이상이면 HIGH이다")
+        void determine_highLevel() {
+            assertThat(calculator.determineScoreLevel(4.0)).isEqualTo(ScoreLevel.HIGH);
+            assertThat(calculator.determineScoreLevel(3.5)).isEqualTo(ScoreLevel.HIGH);
+            System.out.println("✅ HIGH 레벨 판정 테스트 통과");
+        }
+
+        @Test
+        @DisplayName("2.5 이상 3.5 미만이면 MID이다")
+        void determine_midLevel() {
+            assertThat(calculator.determineScoreLevel(3.0)).isEqualTo(ScoreLevel.MID);
+            assertThat(calculator.determineScoreLevel(2.5)).isEqualTo(ScoreLevel.MID);
+            System.out.println("✅ MID 레벨 판정 테스트 통과");
+        }
+
+        @Test
+        @DisplayName("2.5 미만이면 LOW이다")
+        void determine_lowLevel() {
+            assertThat(calculator.determineScoreLevel(2.0)).isEqualTo(ScoreLevel.LOW);
+            System.out.println("✅ LOW 레벨 판정 테스트 통과");
+        }
+    }
+
+    private void setId(Object target, Long id) {
+        try {
+            var field = target.getClass().getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(target, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeQuestionAdminServiceTest.java
+++ b/src/test/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeQuestionAdminServiceTest.java
@@ -1,0 +1,280 @@
+package com.graydang.app.domain.politicaltype.service;
+
+import com.graydang.app.domain.politicaltype.dto.request.QuestionSyncRequest;
+import com.graydang.app.domain.politicaltype.dto.request.QuestionSyncRequest.QuestionSyncItem;
+import com.graydang.app.domain.politicaltype.dto.request.QuestionUpdateRequest;
+import com.graydang.app.domain.politicaltype.dto.response.QuestionAdminResponse;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeQuestionRepository;
+import com.graydang.app.global.common.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PoliticalTypeQuestionAdminServiceTest {
+
+    @InjectMocks
+    private PoliticalTypeQuestionAdminService questionAdminService;
+
+    @Mock
+    private PoliticalTypeQuestionRepository questionRepository;
+
+    private PoliticalTypeQuestion createQuestion(Long id, String content, MetricType type, int order) {
+        PoliticalTypeQuestion q = PoliticalTypeQuestion.builder()
+                .content(content)
+                .metricType(type)
+                .reverseScored(false)
+                .displayOrder(order)
+                .build();
+        // 리플렉션으로 id 설정 (JPA 미사용 환경)
+        setField(q, "id", id);
+        return q;
+    }
+
+    @Nested
+    @DisplayName("getQuestion 문항 단건 조회 시")
+    class GetQuestionTest {
+
+        @Test
+        @DisplayName("존재하는 ID면 문항을 반환한다")
+        void getQuestion_shouldReturnQuestion() {
+            PoliticalTypeQuestion q = createQuestion(1L, "테스트 문항", MetricType.PARTICIPATION, 1);
+            given(questionRepository.findById(1L)).willReturn(Optional.of(q));
+
+            QuestionAdminResponse response = questionAdminService.getQuestion(1L);
+
+            assertThat(response.getContent()).isEqualTo("테스트 문항");
+            assertThat(response.getDisplayOrder()).isEqualTo(1);
+            System.out.println("✅ getQuestion 테스트 통과 - 단건 조회 성공");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID면 BusinessException을 던진다")
+        void getQuestion_shouldThrowWhenNotFound() {
+            given(questionRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> questionAdminService.getQuestion(999L))
+                    .isInstanceOf(BusinessException.class);
+
+            System.out.println("✅ getQuestion_shouldThrowWhenNotFound 테스트 통과");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateQuestion 문항 단건 수정 시")
+    class UpdateQuestionTest {
+
+        @Test
+        @DisplayName("내용만 수정하고 displayOrder는 변경하지 않는다")
+        void updateQuestion_shouldUpdateContentOnly() {
+            PoliticalTypeQuestion q = createQuestion(1L, "원본", MetricType.PARTICIPATION, 1);
+            given(questionRepository.findById(1L)).willReturn(Optional.of(q));
+
+            QuestionUpdateRequest request = new QuestionUpdateRequest();
+            setField(request, "content", "수정된 문항");
+            setField(request, "metricType", MetricType.CHANGE_PREFERENCE);
+            setField(request, "reverseScored", true);
+
+            QuestionAdminResponse response = questionAdminService.updateQuestion(1L, request);
+
+            assertThat(response.getContent()).isEqualTo("수정된 문항");
+            assertThat(response.getMetricType()).isEqualTo(MetricType.CHANGE_PREFERENCE);
+            assertThat(response.getDisplayOrder()).isEqualTo(1);
+            System.out.println("✅ updateQuestion 테스트 통과 - 내용만 수정, displayOrder 유지");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteQuestion 문항 삭제 시")
+    class DeleteQuestionTest {
+
+        @Test
+        @DisplayName("삭제 후 나머지 문항 displayOrder가 재정렬된다")
+        void deleteQuestion_shouldReorderRemaining() {
+            PoliticalTypeQuestion q1 = createQuestion(1L, "Q1", MetricType.PARTICIPATION, 1);
+            PoliticalTypeQuestion q2 = createQuestion(2L, "Q2", MetricType.CHANGE_PREFERENCE, 2);
+            PoliticalTypeQuestion q3 = createQuestion(3L, "Q3", MetricType.VALUE_ORIENTATION, 3);
+
+            given(questionRepository.findById(2L)).willReturn(Optional.of(q2));
+            // 삭제 후 남은 문항 (q1, q3)
+            given(questionRepository.findAllByOrderByDisplayOrderAsc())
+                    .willReturn(new ArrayList<>(List.of(q1, q3)));
+
+            questionAdminService.deleteQuestion(2L);
+
+            verify(questionRepository).deleteById(2L);
+            // q3의 displayOrder가 3 → 2로 변경되어야 함
+            assertThat(q3.getDisplayOrder()).isEqualTo(2);
+            System.out.println("✅ deleteQuestion 테스트 통과 - displayOrder 재정렬 확인 (q3: 3→2)");
+        }
+    }
+
+    @Nested
+    @DisplayName("syncQuestions 벌크 동기화 시")
+    class SyncQuestionsTest {
+
+        @Test
+        @DisplayName("신규 생성, 수정, 삭제를 한 번에 처리한다")
+        void syncQuestions_shouldCreateUpdateDelete() {
+            // 기존 DB: Q1(id=1), Q2(id=2)
+            PoliticalTypeQuestion q1 = createQuestion(1L, "Q1", MetricType.PARTICIPATION, 1);
+            PoliticalTypeQuestion q2 = createQuestion(2L, "Q2", MetricType.CHANGE_PREFERENCE, 2);
+            given(questionRepository.findAll()).willReturn(new ArrayList<>(List.of(q1, q2)));
+
+            // 요청: [Q1 수정, 신규] → Q2는 삭제됨
+            QuestionSyncItem item1 = new QuestionSyncItem();
+            setField(item1, "id", 1L);
+            setField(item1, "content", "Q1 수정됨");
+            setField(item1, "metricType", MetricType.PARTICIPATION);
+
+            QuestionSyncItem newItem = new QuestionSyncItem();
+            setField(newItem, "content", "새 문항");
+            setField(newItem, "metricType", MetricType.VALUE_ORIENTATION);
+
+            QuestionSyncRequest request = new QuestionSyncRequest();
+            setField(request, "questions", List.of(item1, newItem));
+
+            PoliticalTypeQuestion savedNew = createQuestion(3L, "새 문항", MetricType.VALUE_ORIENTATION, 2);
+            given(questionRepository.save(any(PoliticalTypeQuestion.class))).willReturn(savedNew);
+
+            List<QuestionAdminResponse> results = questionAdminService.syncQuestions(request);
+
+            // Q2 삭제 확인
+            verify(questionRepository).deleteAllById(List.of(2L));
+            // Q1 수정 확인
+            assertThat(q1.getContent()).isEqualTo("Q1 수정됨");
+            assertThat(q1.getDisplayOrder()).isEqualTo(1);
+            // 결과 2건
+            assertThat(results).hasSize(2);
+            System.out.println("✅ syncQuestions 테스트 통과 - 생성/수정/삭제 일괄 처리");
+        }
+
+        @Test
+        @DisplayName("순서만 변경하면 displayOrder만 업데이트된다")
+        void syncQuestions_reorderOnly_shouldUpdateDisplayOrder() {
+            // 기존: Q1(order=1), Q2(order=2)
+            PoliticalTypeQuestion q1 = createQuestion(1L, "Q1", MetricType.PARTICIPATION, 1);
+            PoliticalTypeQuestion q2 = createQuestion(2L, "Q2", MetricType.CHANGE_PREFERENCE, 2);
+            given(questionRepository.findAll()).willReturn(new ArrayList<>(List.of(q1, q2)));
+
+            // 요청: [Q2, Q1] → 순서 뒤집기
+            QuestionSyncItem item2 = new QuestionSyncItem();
+            setField(item2, "id", 2L);
+            setField(item2, "content", "Q2");
+            setField(item2, "metricType", MetricType.CHANGE_PREFERENCE);
+
+            QuestionSyncItem item1 = new QuestionSyncItem();
+            setField(item1, "id", 1L);
+            setField(item1, "content", "Q1");
+            setField(item1, "metricType", MetricType.PARTICIPATION);
+
+            QuestionSyncRequest request = new QuestionSyncRequest();
+            setField(request, "questions", List.of(item2, item1));
+
+            List<QuestionAdminResponse> results = questionAdminService.syncQuestions(request);
+
+            assertThat(q2.getDisplayOrder()).isEqualTo(1);
+            assertThat(q1.getDisplayOrder()).isEqualTo(2);
+            assertThat(results).hasSize(2);
+            System.out.println("✅ syncQuestions 순서변경만 테스트 통과 - Q2→1, Q1→2");
+        }
+
+        @Test
+        @DisplayName("빈 DB에서 전부 신규 생성한다")
+        void syncQuestions_emptyDb_shouldCreateAll() {
+            given(questionRepository.findAll()).willReturn(new ArrayList<>());
+
+            QuestionSyncItem newItem1 = new QuestionSyncItem();
+            setField(newItem1, "content", "새 문항 1");
+            setField(newItem1, "metricType", MetricType.PARTICIPATION);
+
+            QuestionSyncItem newItem2 = new QuestionSyncItem();
+            setField(newItem2, "content", "새 문항 2");
+            setField(newItem2, "metricType", MetricType.CHANGE_PREFERENCE);
+
+            QuestionSyncRequest request = new QuestionSyncRequest();
+            setField(request, "questions", List.of(newItem1, newItem2));
+
+            PoliticalTypeQuestion saved1 = createQuestion(1L, "새 문항 1", MetricType.PARTICIPATION, 1);
+            PoliticalTypeQuestion saved2 = createQuestion(2L, "새 문항 2", MetricType.CHANGE_PREFERENCE, 2);
+            given(questionRepository.save(any(PoliticalTypeQuestion.class)))
+                    .willReturn(saved1, saved2);
+
+            List<QuestionAdminResponse> results = questionAdminService.syncQuestions(request);
+
+            assertThat(results).hasSize(2);
+            System.out.println("✅ syncQuestions 전부 신규 테스트 통과 - 2건 생성");
+        }
+
+        @Test
+        @DisplayName("빈 리스트 전송 시 기존 문항 전부 삭제한다")
+        void syncQuestions_emptyList_shouldDeleteAll() {
+            PoliticalTypeQuestion q1 = createQuestion(1L, "Q1", MetricType.PARTICIPATION, 1);
+            PoliticalTypeQuestion q2 = createQuestion(2L, "Q2", MetricType.CHANGE_PREFERENCE, 2);
+            given(questionRepository.findAll()).willReturn(new ArrayList<>(List.of(q1, q2)));
+
+            QuestionSyncRequest request = new QuestionSyncRequest();
+            setField(request, "questions", List.of());
+
+            List<QuestionAdminResponse> results = questionAdminService.syncQuestions(request);
+
+            verify(questionRepository).deleteAllById(List.of(1L, 2L));
+            assertThat(results).isEmpty();
+            System.out.println("✅ syncQuestions 전부 삭제 테스트 통과 - 빈 리스트 → 2건 삭제");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID가 요청에 있으면 BusinessException을 던진다")
+        void syncQuestions_invalidId_shouldThrow() {
+            given(questionRepository.findAll()).willReturn(new ArrayList<>());
+
+            QuestionSyncItem invalidItem = new QuestionSyncItem();
+            setField(invalidItem, "id", 999L);
+            setField(invalidItem, "content", "존재하지 않는 문항");
+            setField(invalidItem, "metricType", MetricType.PARTICIPATION);
+
+            QuestionSyncRequest request = new QuestionSyncRequest();
+            setField(request, "questions", List.of(invalidItem));
+
+            assertThatThrownBy(() -> questionAdminService.syncQuestions(request))
+                    .isInstanceOf(BusinessException.class);
+
+            System.out.println("✅ syncQuestions 존재하지 않는 ID 테스트 통과 - 예외 발생");
+        }
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (NoSuchFieldException e) {
+            // 부모 클래스 탐색
+            try {
+                var field = target.getClass().getSuperclass().getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeServiceTest.java
+++ b/src/test/java/com/graydang/app/domain/politicaltype/service/PoliticalTypeServiceTest.java
@@ -1,0 +1,340 @@
+package com.graydang.app.domain.politicaltype.service;
+
+import com.graydang.app.domain.politicaltype.dto.request.TestSubmitRequest;
+import com.graydang.app.domain.politicaltype.dto.response.AnimalDetailResponse;
+import com.graydang.app.domain.politicaltype.dto.response.QuestionResponse;
+import com.graydang.app.domain.politicaltype.dto.response.RankingResponse;
+import com.graydang.app.domain.politicaltype.dto.response.TestResultResponse;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeAnimal;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeQuestion;
+import com.graydang.app.domain.politicaltype.model.PoliticalTypeTestResult;
+import com.graydang.app.domain.politicaltype.model.enums.ActionStyle;
+import com.graydang.app.domain.politicaltype.model.enums.MetricType;
+import com.graydang.app.domain.politicaltype.model.enums.ScoreLevel;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeAnimalRepository;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeQuestionRepository;
+import com.graydang.app.domain.politicaltype.repository.PoliticalTypeTestResultRepository;
+import com.graydang.app.domain.user.model.User;
+import com.graydang.app.global.common.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PoliticalTypeServiceTest {
+
+    @InjectMocks
+    private PoliticalTypeService politicalTypeService;
+
+    @Mock
+    private PoliticalTypeQuestionRepository questionRepository;
+
+    @Mock
+    private PoliticalTypeAnimalRepository animalRepository;
+
+    @Mock
+    private PoliticalTypeTestResultRepository resultRepository;
+
+    @Mock
+    private PoliticalTypeCalculator calculator;
+
+    // ── 공통 테스트 헬퍼 ──────────────────────────────────────
+
+    private PoliticalTypeQuestion createQuestion(Long id, MetricType type) {
+        PoliticalTypeQuestion q = PoliticalTypeQuestion.builder()
+                .content("테스트 문항 " + id)
+                .metricType(type)
+                .reverseScored(false)
+                .displayOrder(id.intValue())
+                .build();
+        setId(q, id);
+        return q;
+    }
+
+    private PoliticalTypeAnimal createAnimal(Long id, String code, String name) {
+        PoliticalTypeAnimal animal = PoliticalTypeAnimal.builder()
+                .code(code)
+                .name(name)
+                .subtitle("테스트 부제")
+                .oneLiner("테스트 한줄")
+                .description("테스트 설명")
+                .keywords(List.of("키워드1"))
+                .representativeFigures(List.of("인물1"))
+                .changePreferenceLevel(ScoreLevel.HIGH)
+                .valueOrientationLevel(ScoreLevel.HIGH)
+                .build();
+        setId(animal, id);
+        return animal;
+    }
+
+    private List<PoliticalTypeQuestion> createQuestions(int count) {
+        return java.util.stream.IntStream.rangeClosed(1, count)
+                .mapToObj(i -> createQuestion((long) i, MetricType.values()[(i - 1) % 3]))
+                .toList();
+    }
+
+    private TestSubmitRequest createSubmitRequest(int count) {
+        List<TestSubmitRequest.AnswerItem> answers = java.util.stream.IntStream.rangeClosed(1, count)
+                .mapToObj(i -> new TestSubmitRequest.AnswerItem((long) i, 4))
+                .toList();
+        return new TestSubmitRequest(answers);
+    }
+
+    // ── Tests ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("getQuestions 문항 조회 시")
+    class GetQuestionsTest {
+
+        @Test
+        @DisplayName("displayOrder 순으로 정렬된 문항을 반환한다")
+        void getQuestions_shouldReturnSortedQuestions() {
+            List<PoliticalTypeQuestion> questions = createQuestions(3);
+            given(questionRepository.findAllByOrderByDisplayOrderAsc()).willReturn(questions);
+
+            List<QuestionResponse> result = politicalTypeService.getQuestions();
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).getQuestionNumber()).isEqualTo(1);
+            System.out.println("✅ 문항 조회 테스트 통과 - " + result.size() + "건 반환");
+        }
+    }
+
+    @Nested
+    @DisplayName("submitTest 검사 제출 시")
+    class SubmitTestTest {
+
+        @Test
+        @DisplayName("비회원이 제출하면 결과만 반환하고 저장하지 않는다")
+        void submitTest_guest_shouldReturnResultWithoutSaving() {
+            List<PoliticalTypeQuestion> questions = createQuestions(3);
+            TestSubmitRequest request = createSubmitRequest(3);
+            PoliticalTypeAnimal dolphin = createAnimal(1L, "DOLPHIN", "돌고래");
+
+            given(questionRepository.findAllByOrderByDisplayOrderAsc()).willReturn(questions);
+            given(calculator.calculateMetricScores(any(), any()))
+                    .willReturn(Map.of(
+                            MetricType.PARTICIPATION, 4.2,
+                            MetricType.CHANGE_PREFERENCE, 3.8,
+                            MetricType.VALUE_ORIENTATION, 4.0));
+            given(calculator.determineActionStyle(4.2)).willReturn(ActionStyle.FLYING);
+            given(calculator.determineScoreLevel(3.8)).willReturn(ScoreLevel.HIGH);
+            given(calculator.determineScoreLevel(4.0)).willReturn(ScoreLevel.HIGH);
+            given(animalRepository.findByChangePreferenceLevelAndValueOrientationLevel(ScoreLevel.HIGH, ScoreLevel.HIGH))
+                    .willReturn(Optional.of(dolphin));
+
+            TestResultResponse result = politicalTypeService.submitTest(request, null);
+
+            assertThat(result.getSaved()).isFalse();
+            assertThat(result.getActionStyleCode()).isEqualTo("FLYING");
+            assertThat(result.getAnimal().getCode()).isEqualTo("DOLPHIN");
+            verify(resultRepository, never()).save(any());
+            System.out.println("✅ 비회원 제출 테스트 통과 - 저장 안 됨, FLYING 돌고래");
+        }
+
+        @Test
+        @DisplayName("회원이 제출하면 결과를 저장한다 (첫 검사)")
+        void submitTest_member_shouldSaveResult() {
+            List<PoliticalTypeQuestion> questions = createQuestions(3);
+            TestSubmitRequest request = createSubmitRequest(3);
+            PoliticalTypeAnimal dolphin = createAnimal(1L, "DOLPHIN", "돌고래");
+            User user = mock(User.class);
+
+            given(questionRepository.findAllByOrderByDisplayOrderAsc()).willReturn(questions);
+            given(calculator.calculateMetricScores(any(), any()))
+                    .willReturn(Map.of(
+                            MetricType.PARTICIPATION, 4.2,
+                            MetricType.CHANGE_PREFERENCE, 3.8,
+                            MetricType.VALUE_ORIENTATION, 4.0));
+            given(calculator.determineActionStyle(4.2)).willReturn(ActionStyle.FLYING);
+            given(calculator.determineScoreLevel(3.8)).willReturn(ScoreLevel.HIGH);
+            given(calculator.determineScoreLevel(4.0)).willReturn(ScoreLevel.HIGH);
+            given(animalRepository.findByChangePreferenceLevelAndValueOrientationLevel(ScoreLevel.HIGH, ScoreLevel.HIGH))
+                    .willReturn(Optional.of(dolphin));
+            given(resultRepository.findByUser(user)).willReturn(Optional.empty());
+
+            TestResultResponse result = politicalTypeService.submitTest(request, user);
+
+            assertThat(result.getSaved()).isTrue();
+            verify(resultRepository).save(any(PoliticalTypeTestResult.class));
+            System.out.println("✅ 회원 첫 검사 테스트 통과 - 결과 저장됨");
+        }
+
+        @Test
+        @DisplayName("회원이 재검사하면 기존 결과를 업데이트한다")
+        void submitTest_retest_shouldUpdateExistingResult() {
+            List<PoliticalTypeQuestion> questions = createQuestions(3);
+            TestSubmitRequest request = createSubmitRequest(3);
+            PoliticalTypeAnimal dolphin = createAnimal(1L, "DOLPHIN", "돌고래");
+            User user = mock(User.class);
+            PoliticalTypeTestResult existingResult = mock(PoliticalTypeTestResult.class);
+
+            given(questionRepository.findAllByOrderByDisplayOrderAsc()).willReturn(questions);
+            given(calculator.calculateMetricScores(any(), any()))
+                    .willReturn(Map.of(
+                            MetricType.PARTICIPATION, 4.2,
+                            MetricType.CHANGE_PREFERENCE, 3.8,
+                            MetricType.VALUE_ORIENTATION, 4.0));
+            given(calculator.determineActionStyle(4.2)).willReturn(ActionStyle.FLYING);
+            given(calculator.determineScoreLevel(3.8)).willReturn(ScoreLevel.HIGH);
+            given(calculator.determineScoreLevel(4.0)).willReturn(ScoreLevel.HIGH);
+            given(animalRepository.findByChangePreferenceLevelAndValueOrientationLevel(ScoreLevel.HIGH, ScoreLevel.HIGH))
+                    .willReturn(Optional.of(dolphin));
+            given(resultRepository.findByUser(user)).willReturn(Optional.of(existingResult));
+
+            TestResultResponse result = politicalTypeService.submitTest(request, user);
+
+            assertThat(result.getSaved()).isTrue();
+            verify(existingResult).updateResult(eq(ActionStyle.FLYING), eq(dolphin), eq(4.2), eq(3.8), eq(4.0));
+            verify(resultRepository, never()).save(any());
+            System.out.println("✅ 재검사 테스트 통과 - 기존 결과 업데이트됨");
+        }
+
+        @Test
+        @DisplayName("답변 수가 문항 수와 다르면 예외를 던진다")
+        void submitTest_invalidAnswerCount_shouldThrow() {
+            List<PoliticalTypeQuestion> questions = createQuestions(3);
+            TestSubmitRequest request = createSubmitRequest(2); // 문항 3개인데 답변 2개
+
+            given(questionRepository.findAllByOrderByDisplayOrderAsc()).willReturn(questions);
+
+            assertThatThrownBy(() -> politicalTypeService.submitTest(request, null))
+                    .isInstanceOf(BusinessException.class);
+            System.out.println("✅ 답변 수 불일치 예외 테스트 통과");
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyResult 내 결과 조회 시")
+    class GetMyResultTest {
+
+        @Test
+        @DisplayName("결과가 존재하면 반환한다")
+        void getMyResult_exists_shouldReturnResult() {
+            User user = mock(User.class);
+            PoliticalTypeAnimal dolphin = createAnimal(1L, "DOLPHIN", "돌고래");
+            PoliticalTypeTestResult testResult = PoliticalTypeTestResult.builder()
+                    .user(user)
+                    .actionStyle(ActionStyle.FLYING)
+                    .animal(dolphin)
+                    .participationScore(4.2)
+                    .changePreferenceScore(3.8)
+                    .valueOrientationScore(4.0)
+                    .build();
+
+            given(resultRepository.findByUser(user)).willReturn(Optional.of(testResult));
+
+            TestResultResponse result = politicalTypeService.getMyResult(user);
+
+            assertThat(result.getActionStyleCode()).isEqualTo("FLYING");
+            assertThat(result.getAnimal().getName()).isEqualTo("돌고래");
+            System.out.println("✅ 내 결과 조회 테스트 통과 - 날아다니는 돌고래");
+        }
+
+        @Test
+        @DisplayName("결과가 없으면 예외를 던진다")
+        void getMyResult_notExists_shouldThrow() {
+            User user = mock(User.class);
+            given(resultRepository.findByUser(user)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> politicalTypeService.getMyResult(user))
+                    .isInstanceOf(BusinessException.class);
+            System.out.println("✅ 결과 없음 예외 테스트 통과");
+        }
+    }
+
+    @Nested
+    @DisplayName("getRanking 랭킹 조회 시")
+    class GetRankingTest {
+
+        @Test
+        @DisplayName("동물유형별 집계 결과를 반환한다")
+        void getRanking_shouldReturnRankings() {
+            PoliticalTypeAnimal dolphin = createAnimal(1L, "DOLPHIN", "돌고래");
+            PoliticalTypeAnimal owl = createAnimal(2L, "OWL", "부엉이");
+
+            given(resultRepository.count()).willReturn(100L);
+            given(resultRepository.countByAnimalGroupBy())
+                    .willReturn(List.of(new Object[]{1L, 60L}, new Object[]{2L, 40L}));
+            given(animalRepository.findAll()).willReturn(List.of(dolphin, owl));
+
+            RankingResponse result = politicalTypeService.getRanking();
+
+            assertThat(result.getTotalParticipants()).isEqualTo(100L);
+            assertThat(result.getRankings()).hasSize(2);
+            assertThat(result.getRankings().get(0).getRank()).isEqualTo(1);
+            assertThat(result.getRankings().get(0).getAnimalName()).isEqualTo("돌고래");
+            assertThat(result.getRankings().get(0).getPercentage()).isEqualTo(60.0);
+            System.out.println("✅ 랭킹 조회 테스트 통과 - 1위 돌고래 60%");
+        }
+    }
+
+    @Nested
+    @DisplayName("getAnimalDetail 유형 상세 조회 시")
+    class GetAnimalDetailTest {
+
+        @Test
+        @DisplayName("코드로 동물유형 상세를 반환한다")
+        void getAnimalDetail_exists_shouldReturn() {
+            PoliticalTypeAnimal dolphin = createAnimal(1L, "DOLPHIN", "돌고래");
+            given(animalRepository.findByCode("DOLPHIN")).willReturn(Optional.of(dolphin));
+
+            AnimalDetailResponse result = politicalTypeService.getAnimalDetail("DOLPHIN");
+
+            assertThat(result.getCode()).isEqualTo("DOLPHIN");
+            assertThat(result.getName()).isEqualTo("돌고래");
+            System.out.println("✅ 유형 상세 조회 테스트 통과 - DOLPHIN");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 코드면 예외를 던진다")
+        void getAnimalDetail_notExists_shouldThrow() {
+            given(animalRepository.findByCode("INVALID")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> politicalTypeService.getAnimalDetail("INVALID"))
+                    .isInstanceOf(BusinessException.class);
+            System.out.println("✅ 존재하지 않는 유형 예외 테스트 통과");
+        }
+    }
+
+    @Nested
+    @DisplayName("getParticipantCount 참여자 수 조회 시")
+    class GetParticipantCountTest {
+
+        @Test
+        @DisplayName("전체 참여자 수를 반환한다")
+        void getParticipantCount_shouldReturnCount() {
+            given(resultRepository.count()).willReturn(20000L);
+
+            long result = politicalTypeService.getParticipantCount();
+
+            assertThat(result).isEqualTo(20000L);
+            System.out.println("✅ 참여자 수 조회 테스트 통과 - 20000명");
+        }
+    }
+
+    // ── Reflection helper ────────────────────────────────────
+
+    private void setId(Object target, Long id) {
+        try {
+            var field = target.getClass().getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(target, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/graydang/app/global/common/converter/StringListConverterTest.java
+++ b/src/test/java/com/graydang/app/global/common/converter/StringListConverterTest.java
@@ -1,0 +1,65 @@
+package com.graydang.app.global.common.converter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StringListConverterTest {
+
+    private final StringListConverter converter = new StringListConverter();
+
+    @Nested
+    @DisplayName("convertToDatabaseColumn으로 List를 JSON으로 변환한다")
+    class ConvertToDatabaseColumnTest {
+
+        @Test
+        @DisplayName("정상 리스트를 JSON 배열로 변환한다")
+        void convertToDatabaseColumn_shouldConvertListToJson() {
+            List<String> input = List.of("자유", "급진", "적극참여");
+
+            String result = converter.convertToDatabaseColumn(input);
+
+            assertThat(result).isEqualTo("[\"자유\",\"급진\",\"적극참여\"]");
+            System.out.println("✅ convertToDatabaseColumn 테스트 통과 - " + result);
+        }
+
+        @Test
+        @DisplayName("null이면 빈 배열 문자열을 반환한다")
+        void convertToDatabaseColumn_shouldReturnEmptyArrayForNull() {
+            String result = converter.convertToDatabaseColumn(null);
+
+            assertThat(result).isEqualTo("[]");
+            System.out.println("✅ null → [] 변환 테스트 통과");
+        }
+    }
+
+    @Nested
+    @DisplayName("convertToEntityAttribute로 JSON을 List로 변환한다")
+    class ConvertToEntityAttributeTest {
+
+        @Test
+        @DisplayName("JSON 배열을 List로 변환한다")
+        void convertToEntityAttribute_shouldConvertJsonToList() {
+            String json = "[\"자유\",\"급진\"]";
+
+            List<String> result = converter.convertToEntityAttribute(json);
+
+            assertThat(result).containsExactly("자유", "급진");
+            System.out.println("✅ convertToEntityAttribute 테스트 통과 - " + result.size() + "건");
+        }
+
+        @Test
+        @DisplayName("null이면 빈 리스트를 반환한다")
+        void convertToEntityAttribute_shouldReturnEmptyListForNull() {
+            List<String> result = converter.convertToEntityAttribute(null);
+
+            assertThat(result).isEqualTo(Collections.emptyList());
+            System.out.println("✅ null → 빈 리스트 변환 테스트 통과");
+        }
+    }
+}


### PR DESCRIPTION
## 정치유형 검사 기능 전체 구현 (도메인 모델 + 관리자 API + 사용자 API)

관련 이슈: #120, #121, #122

변경 사항

### 도메인 (#120)

- 검사 문항 / 동물유형 / 검사 결과 엔티티 및 Repository

### 관리자 API (#121)

- 동물유형 CRUD + 이미지 관리 (/api/admin/political-type/animals)
- 문항 일괄 동기화 및 개별 수정/삭제 (/api/admin/political-type/questions)
- @PreAuthorize Service 계층 적용

### 사용자 API (#122)

- 문항 조회, 검사 제출(비회원 가능), 결과 저장/조회, 랭킹, 유형 상세, 참여자 수
- 비회원 제출 → 로그인 후 /save로 저장 가능
- 재검사 시 기존 결과 덮어쓰기 (유저당 1건)

### 테스트
- PoliticalTypeCalculatorTest — 점수 계산 로직
- PoliticalTypeServiceTest — 사용자 시나리오 11건
- PoliticalTypeAnimalAdminServiceTest / PoliticalTypeQuestionAdminServiceTest — 관리자 CRUD